### PR TITLE
Update default socket path

### DIFF
--- a/src/Config/Source/DerivedSource.php
+++ b/src/Config/Source/DerivedSource.php
@@ -62,7 +62,7 @@ class DerivedSource
         $dir      = $this->config->get('core_agent_dir');
         $fullName = $this->config->get('core_agent_full_name');
 
-        return $dir . '/' . $fullName . '/core-agent.sock';
+        return $dir . '/' . $fullName . '/scout-agent.sock';
     }
 
     private function coreAgentFullName() : string


### PR DESCRIPTION
Mirror of https://github.com/scoutapp/scout_apm_python/pull/240 for this library. The core agent has used the default socket name `scout-agent.sock` when started solo since version 1.0.0, so match it.