### PR TITLE
Loosen version requirement for ralouphie/getallheaders

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "ext-json": "*",
         "ext-sockets": "*",
         "psr/log": "^1.1",
-        "ralouphie/getallheaders": ">= 2.0.5",
+        "ralouphie/getallheaders": "^2.0.5|^3.0",
         "ramsey/uuid": "^3.7"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "ext-json": "*",
         "ext-sockets": "*",
         "psr/log": "^1.1",
-        "ralouphie/getallheaders": "2.0.5",
+        "ralouphie/getallheaders": ">= 2.0.5",
         "ramsey/uuid": "^3.7"
     },
     "require-dev": {


### PR DESCRIPTION
Some users have 3.x required in their Laravel apps, and both 2.x and 3.x work fine. There's little to no chance of backwards incompatible changes in this library because it's meant to polyfill a single, defined-elsewhere function. Even the 2.x to 3.x was just dropping support for very old PHPs.