### PR TITLE
Lock CoreAgent to 1.2.1

### DIFF
--- a/src/Config/Source/DefaultSource.php
+++ b/src/Config/Source/DefaultSource.php
@@ -57,7 +57,7 @@ class DefaultSource
             'core_agent_dir' => '/tmp/scout_apm_core',
             'core_agent_download' => true,
             'core_agent_launch' => true,
-            'core_agent_version' => 'latest',
+            'core_agent_version' => 'v1.2.1',
             'download_url' => 'https://s3-us-west-1.amazonaws.com/scout-public-downloads/apm_core_agent/release',
             'monitor' => false,
             'ignore' => [],

--- a/src/CoreAgent/Downloader.php
+++ b/src/CoreAgent/Downloader.php
@@ -138,7 +138,16 @@ class Downloader
 
     private function downloadPackage() : void
     {
-        copy($this->fullUrl(), $this->package_location);
+        $fullUrl = $this->fullUrl();
+        copy($fullUrl, $this->package_location);
+
+        if (!file_exists($this->package_location)) {
+            throw new \RuntimeException(sprintf(
+                'Downloaded file did not exist (tried downloading %s to %s)',
+                $fullUrl,
+                $this->package_location
+            ));
+        }
     }
 
     private function untar() : void


### PR DESCRIPTION
Unfortunately, the version `latest` actually resolves to a CoreAgent from
several versions ago. I'll be fixing that separately.

All of the other language agents lock to an exact version anyway, so that's a
better choice for this one as well.