### PR TITLE
Updates CoreAgent to 1.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
  - Added memory usage statistics to request (#89)
  - Suppress backtraces for Controller, Job, and Middleware spans (#96)
  - Tag the request URI automatically with `$_SERVER['REQUEST_URI']` or override with alternative (#102)
+ - Update CoreAgent to 1.2.4 (#103)
 
 ### Fixed
 

--- a/src/Config/Source/DefaultSource.php
+++ b/src/Config/Source/DefaultSource.php
@@ -58,7 +58,7 @@ class DefaultSource
             ConfigKey::CORE_AGENT_DIRECTORY => '/tmp/scout_apm_core',
             ConfigKey::CORE_AGENT_DOWNLOAD_ENABLED => true,
             ConfigKey::CORE_AGENT_LAUNCH_ENABLED => true,
-            ConfigKey::CORE_AGENT_VERSION => 'v1.2.2',
+            ConfigKey::CORE_AGENT_VERSION => 'v1.2.4',
             ConfigKey::CORE_AGENT_DOWNLOAD_URL => 'https://s3-us-west-1.amazonaws.com/scout-public-downloads/apm_core_agent/release',
             ConfigKey::CORE_AGENT_PERMISSIONS => 0777,
             ConfigKey::MONITORING_ENABLED => false,


### PR DESCRIPTION
A few bug fixes, but most notable fix is better parsing/naming of SQL
emitted in real-life by Laravel. So instead of having "SQL" as the name
of the row in the web UI, it will say "User/Select" or "Post/Update" and
so on more often.

Note: it wasn't skipping any instrumented SQL previously, just was
falling back to a generic name for it.