### PR TITLE
Improvements to API and logging/debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
 
  - Added `language_version` key to be sent with metadata (#110)
  - Added more debug logging to isolate issues easier (#111, #115)
+ - **[BC]** `\Scoutapm\Connector\Connector::sendCommand` now returns `string` not `bool`
+ - **[BC]** `\Scoutapm\Agent::fromConfig()` second parameter for a `\Psr\Log\LoggerInterface` implementation is no longer optional
+   - You should pass in an implementation of `\Psr\Log\LoggerInterface` as the second parameter
+   - If you do not want logging, you can use `\Psr\Log\NullLogger` (although this is not advisable)
+ - **[BC]** `\Scoutapm\Agent::__construct` is now private
+   - Use the named constructor `\Scoutapm\Agent::fromConfig()` instead
+
+### Removed
+ - **[BC]** `\Scoutapm\Agent::fromDefaults()` named constructor was removed
+   - For exactly matching behaviour, use `::fromConfig(new \Scoutapm\Config(), new \Psr\Log\NullLogger())`
 
 ## [1.0.0] 2019-11-05
 

--- a/README.md
+++ b/README.md
@@ -25,15 +25,22 @@ To install the ScoutAPM Agent for a specific framework, use the specific package
 ### Using the base library directly
 
 ```php
+use Psr\Log\LoggerInterface;
 use Scoutapm\Agent;
 use Scoutapm\Config;
 use Scoutapm\Config\ConfigKey;
 
-$agent = Agent::fromConfig(Config::fromArray([
-    ConfigKey::APPLICATION_NAME => 'Your application name',
-    ConfigKey::APPLICATION_KEY => 'your scout key',
-    ConfigKey::MONITORING_ENABLED => true,
-]));
+// It is assumed you are using a PSR Logger
+/** @var LoggerInterface $psrLoggerImplementation */
+
+$agent = Agent::fromConfig(
+    Config::fromArray([
+        ConfigKey::APPLICATION_NAME => 'Your application name',
+        ConfigKey::APPLICATION_KEY => 'your scout key',
+        ConfigKey::MONITORING_ENABLED => true,
+    ]),
+    $psrLoggerImplementation
+);
 // If the core agent is not already running, this will download and run it (from /tmp by default)
 $agent->connect();
 
@@ -41,6 +48,33 @@ $agent->connect();
 
 // Nothing is sent to Scout until you call this - so call this at the end of your request
 $agent->send();
+```
+
+#### Default log level
+
+By default, the library is *very* noisy in logging by design - this is to help us figure out what is going wrong if you
+need assistance. If you are confident everything is working, and you can see data in your Scout dashboard, then you
+can increase the minimum log level by adding the following configuration to set the "minimum" log level (which **only**
+applies to Scout's logging):
+
+```php
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Scoutapm\Agent;
+use Scoutapm\Config;
+use Scoutapm\Config\ConfigKey;
+
+/** @var LoggerInterface $psrLoggerImplementation */
+
+$agent = Agent::fromConfig(
+    Config::fromArray([
+        ConfigKey::APPLICATION_NAME => 'Your application name',
+        ConfigKey::APPLICATION_KEY => 'your scout key',
+        ConfigKey::MONITORING_ENABLED => true,
+        ConfigKey::LOG_LEVEL => LogLevel::ERROR, // <-- add this configuration
+    ]),
+    $psrLoggerImplementation
+);
 ```
 
 ## Monitoring of PHP internal functions

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -102,23 +102,6 @@ final class Agent implements ScoutApmAgent
         return new SocketConnector($config->get(ConfigKey::CORE_AGENT_SOCKET_PATH));
     }
 
-    /**
-     * @deprecated Once getConfig is removed, you cannot overwrite config using this...
-     *
-     * @todo alternative API to be discussed...
-     */
-    public static function fromDefaults(?LoggerInterface $logger = null, ?Connector $connector = null) : self
-    {
-        $config = new Config();
-
-        return new self(
-            $config,
-            $connector ?? self::createConnectorFromConfig($config),
-            $logger ?? new NullLogger(),
-            new PotentiallyAvailableExtensionCapabilities()
-        );
-    }
-
     public static function fromConfig(Config $config, ?LoggerInterface $logger = null, ?Connector $connector = null) : self
     {
         return new self(

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -61,7 +61,7 @@ final class Agent implements ScoutApmAgent
     /** @var ExtentionCapabilities */
     private $phpExtension;
 
-    public function __construct(Config $configuration, Connector $connector, LoggerInterface $logger, ExtentionCapabilities $phpExtension)
+    private function __construct(Config $configuration, Connector $connector, LoggerInterface $logger, ExtentionCapabilities $phpExtension)
     {
         $this->config       = $configuration;
         $this->connector    = $connector;

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -316,36 +316,25 @@ final class Agent implements ScoutApmAgent
         }
 
         try {
-            if (! $this->connector->sendCommand(new RegisterMessage(
+            $this->connector->sendCommand(new RegisterMessage(
                 (string) $this->config->get(ConfigKey::APPLICATION_NAME),
                 (string) $this->config->get(ConfigKey::APPLICATION_KEY),
                 $this->config->get(ConfigKey::API_VERSION)
-            ))) {
-                $this->logger->debug('Send command returned false for RegisterMessage');
+            ));
 
-                return false;
-            }
-
-            if (! $this->connector->sendCommand(new Metadata(
+            $this->connector->sendCommand(new Metadata(
                 new DateTimeImmutable('now', new DateTimeZone('UTC')),
                 $this->config
-            ))) {
-                $this->logger->debug('Send command returned false for Metadata');
-
-                return false;
-            }
+            ));
 
             $this->request->stopIfRunning();
 
             $this->logger->debug(sprintf('Sending metrics from %d collected spans', $this->request->collectedSpans()));
 
-            if (! $this->connector->sendCommand($this->request)) {
-                $this->logger->debug('Send command returned false for Request');
-
-                return false;
-            }
-
-            $this->logger->debug('Sent whole payload successfully to core agent.');
+            $this->logger->debug(sprintf(
+                'Sent whole payload successfully to core agent. Core agent response was: %s',
+                $this->connector->sendCommand($this->request)
+            ));
 
             return true;
         } catch (NotConnected $notConnected) {

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -8,7 +8,6 @@ use Closure;
 use DateTimeImmutable;
 use DateTimeZone;
 use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
 use Scoutapm\Config\ConfigKey;
 use Scoutapm\Config\IgnoredEndpoints;
 use Scoutapm\Connector\Connector;
@@ -102,12 +101,12 @@ final class Agent implements ScoutApmAgent
         return new SocketConnector($config->get(ConfigKey::CORE_AGENT_SOCKET_PATH));
     }
 
-    public static function fromConfig(Config $config, ?LoggerInterface $logger = null, ?Connector $connector = null) : self
+    public static function fromConfig(Config $config, LoggerInterface $logger, ?Connector $connector = null) : self
     {
         return new self(
             $config,
             $connector ?? self::createConnectorFromConfig($config),
-            $logger ?? new NullLogger(),
+            $logger,
             new PotentiallyAvailableExtensionCapabilities()
         );
     }

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -337,6 +337,8 @@ final class Agent implements ScoutApmAgent
 
             $this->request->stopIfRunning();
 
+            $this->logger->debug(sprintf('Sending metrics from %d collected spans', $this->request->collectedSpans()));
+
             if (! $this->connector->sendCommand($this->request)) {
                 $this->logger->debug('Send command returned false for Request');
 

--- a/src/Connector/Connector.php
+++ b/src/Connector/Connector.php
@@ -15,7 +15,7 @@ interface Connector
     public function connected() : bool;
 
     /** @throws NotConnected */
-    public function sendCommand(Command $message) : bool;
+    public function sendCommand(Command $message) : string;
 
     public function shutdown() : void;
 }

--- a/src/Connector/SocketConnector.php
+++ b/src/Connector/SocketConnector.php
@@ -69,7 +69,7 @@ final class SocketConnector implements Connector
         return $this->connected;
     }
 
-    public function sendCommand(Command $message) : bool
+    public function sendCommand(Command $message) : string
     {
         if (! $this->connected()) {
             throw NotConnected::fromSocketPath($this->socketPath);
@@ -97,11 +97,13 @@ final class SocketConnector implements Connector
             throw Exception\FailedToSendCommand::readingResponseSizeFromSocket($message, $this->socket, $this->socketPath);
         }
 
-        if (socket_read($this->socket, unpack('N', $responseLength)[1]) === false) {
+        $dataRead = socket_read($this->socket, unpack('N', $responseLength)[1]);
+
+        if ($dataRead === false) {
             throw Exception\FailedToSendCommand::readingResponseContentFromSocket($message, $this->socket, $this->socketPath);
         }
 
-        return true;
+        return $dataRead;
     }
 
     public function shutdown() : void

--- a/src/CoreAgent/AutomaticDownloadAndLaunchManager.php
+++ b/src/CoreAgent/AutomaticDownloadAndLaunchManager.php
@@ -146,13 +146,16 @@ final class AutomaticDownloadAndLaunchManager implements Manager
 
             $escapedCommand = implode(' ', array_map('escapeshellarg', $commandParts));
 
-            $this->logger->debug('Core Agent: ' . $escapedCommand);
+            $this->logger->debug(sprintf('Launching core agent with command: %s', $escapedCommand));
             exec($escapedCommand);
 
             return true;
         } catch (Throwable $e) {
-            // TODO detect failure of launch properly
-            // logger.error("Error running Core Agent: %r", e);
+            $this->logger->debug(
+                sprintf('Failed to launch core agent - exception %s', $e->getMessage()),
+                ['exception' => $e]
+            );
+
             return false;
         }
     }

--- a/src/Events/Request/Request.php
+++ b/src/Events/Request/Request.php
@@ -11,6 +11,7 @@ use Scoutapm\Events\Span\Span;
 use Scoutapm\Events\Tag\Tag;
 use Scoutapm\Events\Tag\TagRequest;
 use Scoutapm\Helper\MemoryUsage;
+use Scoutapm\Helper\RecursivelyCountSpans;
 use Scoutapm\Helper\Timer;
 use function is_string;
 
@@ -161,6 +162,11 @@ class Request implements CommandWithChildren
         return [
             'BatchCommand' => ['commands' => $commands],
         ];
+    }
+
+    public function collectedSpans() : int
+    {
+        return RecursivelyCountSpans::forCommands($this->children);
     }
 
     /**

--- a/src/Events/Span/Span.php
+++ b/src/Events/Span/Span.php
@@ -12,6 +12,7 @@ use Scoutapm\Events\Request\RequestId;
 use Scoutapm\Events\Tag\Tag;
 use Scoutapm\Events\Tag\TagSpan;
 use Scoutapm\Helper\Backtrace;
+use Scoutapm\Helper\RecursivelyCountSpans;
 use Scoutapm\Helper\Timer;
 use function array_filter;
 use function strpos;
@@ -127,6 +128,11 @@ class Span implements CommandWithParent, CommandWithChildren
     public function duration() : ?float
     {
         return $this->timer->duration();
+    }
+
+    public function collectedSpans() : int
+    {
+        return RecursivelyCountSpans::forCommands($this->children);
     }
 
     /**

--- a/src/Helper/RecursivelyCountSpans.php
+++ b/src/Helper/RecursivelyCountSpans.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scoutapm\Helper;
+
+use Scoutapm\Connector\Command;
+use Scoutapm\Events\Span\Span;
+use function array_reduce;
+
+abstract class RecursivelyCountSpans
+{
+    /** @param Command[] $commands */
+    public static function forCommands(array $commands) : int
+    {
+        return (int) array_reduce(
+            $commands,
+            static function (int $carry, Command $item) : int {
+                if (! $item instanceof Span) {
+                    return $carry;
+                }
+
+                return $carry + 1 + $item->collectedSpans();
+            },
+            0
+        );
+    }
+}

--- a/tests/Integration/MessageCapturingConnectorDelegator.php
+++ b/tests/Integration/MessageCapturingConnectorDelegator.php
@@ -30,7 +30,7 @@ final class MessageCapturingConnectorDelegator implements Connector
         return $this->delegate->connected();
     }
 
-    public function sendCommand(Command $message) : bool
+    public function sendCommand(Command $message) : string
     {
         $this->sentMessages[] = $message;
 

--- a/tests/Unit/AgentTest.php
+++ b/tests/Unit/AgentTest.php
@@ -265,7 +265,7 @@ final class AgentTest extends TestCase
         $config = new Config();
         $config->set(ConfigKey::IGNORED_ENDPOINTS, ['/foo']);
 
-        $agent = Agent::fromConfig($config);
+        $agent = Agent::fromConfig($config, new NullLogger());
 
         self::assertTrue($agent->ignored('/foo'));
         self::assertFalse($agent->ignored('/bar'));

--- a/tests/Unit/AgentTest.php
+++ b/tests/Unit/AgentTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
+use Psr\Log\NullLogger;
 use Scoutapm\Agent;
 use Scoutapm\Config;
 use Scoutapm\Config\ConfigKey;
@@ -144,7 +145,7 @@ final class AgentTest extends TestCase
 
     public function testFullAgentSequence() : void
     {
-        $agent = Agent::fromDefaults();
+        $agent = Agent::fromConfig(new Config(), new NullLogger());
 
         // Start a Parent Controller Span
         $agent->startSpan('Controller/Test');
@@ -169,7 +170,7 @@ final class AgentTest extends TestCase
 
     public function testInstrument() : void
     {
-        $agent  = Agent::fromDefaults();
+        $agent  = Agent::fromConfig(new Config(), new NullLogger());
         $retval = $agent->instrument('Custom', 'Test', static function (Span $span) {
             $span->tag('OMG', 'Thingy');
 
@@ -192,7 +193,7 @@ final class AgentTest extends TestCase
 
     public function testWebTransaction() : void
     {
-        $retval = Agent::fromDefaults()->webTransaction('Test', static function (Span $span) {
+        $retval = Agent::fromConfig(new Config(), new NullLogger())->webTransaction('Test', static function (Span $span) {
             // Check span name is prefixed with "Controller"
             self::assertSame($span->getName(), 'Controller/Test');
 
@@ -204,7 +205,7 @@ final class AgentTest extends TestCase
 
     public function testBackgroundTransaction() : void
     {
-        $retval = Agent::fromDefaults()->backgroundTransaction('Test', static function (Span $span) {
+        $retval = Agent::fromConfig(new Config(), new NullLogger())->backgroundTransaction('Test', static function (Span $span) {
             // Check span name is prefixed with "Job"
             self::assertSame($span->getName(), 'Job/Test');
 
@@ -216,13 +217,13 @@ final class AgentTest extends TestCase
 
     public function testStartSpan() : void
     {
-        $span = Agent::fromDefaults()->startSpan('foo/bar');
+        $span = Agent::fromConfig(new Config(), new NullLogger())->startSpan('foo/bar');
         self::assertSame('foo/bar', $span->getName());
     }
 
     public function testStopSpan() : void
     {
-        $agent = Agent::fromDefaults();
+        $agent = Agent::fromConfig(new Config(), new NullLogger());
         $span  = $agent->startSpan('foo/bar');
         self::assertNull($span->getStopTime());
 
@@ -233,7 +234,7 @@ final class AgentTest extends TestCase
 
     public function testTagRequest() : void
     {
-        $agent = Agent::fromDefaults();
+        $agent = Agent::fromConfig(new Config(), new NullLogger());
         $agent->tagRequest('foo', 'bar');
 
         $events = $agent->getRequest()->getEvents();
@@ -248,14 +249,14 @@ final class AgentTest extends TestCase
     public function testEnabled() : void
     {
         // without affirmatively enabling, it's not enabled.
-        $agentWithoutEnabling = Agent::fromDefaults();
+        $agentWithoutEnabling = Agent::fromConfig(new Config(), new NullLogger());
         self::assertFalse($agentWithoutEnabling->enabled());
 
         // but a config that has monitor = true, it is set
         $config = new Config();
         $config->set(ConfigKey::MONITORING_ENABLED, 'true');
 
-        $enabledAgent = Agent::fromConfig($config);
+        $enabledAgent = Agent::fromConfig($config, new NullLogger());
         self::assertTrue($enabledAgent->enabled());
     }
 
@@ -275,7 +276,7 @@ final class AgentTest extends TestCase
      */
     public function testIgnoredAgentSequence() : void
     {
-        $agent = Agent::fromDefaults();
+        $agent = Agent::fromConfig(new Config(), new NullLogger());
         $agent->ignore();
 
         // Start a Parent Controller Span

--- a/tests/Unit/Events/Request/RequestTest.php
+++ b/tests/Unit/Events/Request/RequestTest.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Scoutapm\UnitTests\Events\Request;
 
+use Exception;
 use PHPUnit\Framework\TestCase;
 use Scoutapm\Events\Request\Request;
+use Scoutapm\Events\Request\RequestId;
+use Scoutapm\Events\Span\Span;
 use function json_decode;
 use function json_encode;
 use function next;
@@ -139,5 +142,19 @@ final class RequestTest extends TestCase
         self::assertArrayHasKey('TagRequest', next($commands));
 
         self::assertArrayHasKey('FinishRequest', next($commands));
+    }
+
+    /** @throws Exception */
+    public function testSpansCanBeCounted() : void
+    {
+        $request = new Request();
+        $request->tag('t', 'v');
+        $span = $request->startSpan('foo');
+        $span->tag('spantag', 'spanvalue');
+        $span->appendChild(new Span($span, 'sub', RequestId::new()));
+        $request->stopSpan();
+        $request->stop();
+
+        self::assertSame(2, $request->collectedSpans());
     }
 }

--- a/tests/Unit/Events/Span/SpanTest.php
+++ b/tests/Unit/Events/Span/SpanTest.php
@@ -56,6 +56,17 @@ final class SpanTest extends TestCase
     }
 
     /** @throws Exception */
+    public function testSpansCanBeCounted() : void
+    {
+        $span = new Span($this->mockParent, '', RequestId::new());
+        $span->tag('Foo', 'Bar');
+        $span->appendChild(new Span($this->mockParent, '', RequestId::new()));
+        $span->stop();
+
+        self::assertSame(1, $span->collectedSpans());
+    }
+
+    /** @throws Exception */
     public function testSpanNameOverride() : void
     {
         $span = new Span($this->mockParent, 'original', RequestId::new());

--- a/tests/Unit/Helper/RecursivelyCountSpansTest.php
+++ b/tests/Unit/Helper/RecursivelyCountSpansTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scoutapm\UnitTests\Helper;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Scoutapm\Connector\Command;
+use Scoutapm\Events\Request\Request;
+use Scoutapm\Events\Request\RequestId;
+use Scoutapm\Events\Span\Span;
+use Scoutapm\Events\Span\SpanId;
+use Scoutapm\Events\Tag\TagRequest;
+use Scoutapm\Events\Tag\TagSpan;
+use Scoutapm\Helper\RecursivelyCountSpans;
+use function uniqid;
+
+/** @covers \Scoutapm\Helper\RecursivelyCountSpans */
+final class RecursivelyCountSpansTest extends TestCase
+{
+    /**
+     * @return Command[][][]|int[][]
+     *
+     * @throws Exception
+     *
+     * @psalm-return array<int, array{commands: array<int, Command>, expectedSpans: int}>
+     */
+    public function commandAndExpectedSpansCountProvider() : array
+    {
+        $spanWithChildren = new Span(new Request(), uniqid('span', true), RequestId::new());
+        $spanWithChildren->appendChild(new Span(new Request(), uniqid('span', true), RequestId::new()));
+        $spanWithChildren->tag(uniqid('tag', true), uniqid('value', true));
+
+        return [
+            [
+                'commands' => [
+                    new Span(new Request(), uniqid('span', true), RequestId::new()),
+                ],
+                'expectedSpans' => 1,
+            ],
+            [
+                'commands' => [],
+                'expectedSpans' => 0,
+            ],
+            [
+                'commands' => [
+                    new TagSpan(uniqid('tag', true), uniqid('value', true), RequestId::new(), SpanId::new()),
+                    new TagRequest(uniqid('tag', true), uniqid('value', true), RequestId::new()),
+                    new Span(new Request(), uniqid('span', true), RequestId::new()),
+                ],
+                'expectedSpans' => 1,
+            ],
+            [
+                'commands' => [
+                    new Span(new Request(), uniqid('span', true), RequestId::new()),
+                    new Span(new Request(), uniqid('span', true), RequestId::new()),
+                ],
+                'expectedSpans' => 2,
+            ],
+            [
+                'commands' => [$spanWithChildren],
+                'expectedSpans' => 2,
+            ],
+        ];
+    }
+
+    /**
+     * @param Command[] $commands
+     *
+     * @dataProvider commandAndExpectedSpansCountProvider
+     */
+    public function testForCommands(array $commands, int $expectedSpans) : void
+    {
+        self::assertSame($expectedSpans, RecursivelyCountSpans::forCommands($commands));
+    }
+}


### PR DESCRIPTION
 - Hardens `Agent` API to require Logger in `::fromConfig()`
 - Removes deprecated API (`Agent::fromDefaults()`)
 - Makes `Agent::__construct` into a `private` method (forces using `::fromConfig()`)
 - Return the data that was read from the socket in `Connector` (for logging, primarily)
 - Adds a bunch of extra logging everywhere
 - Adds docs on how to turn off all the logging