### PR TITLE
Send metadata less often

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
    - If you do not want logging, you can use `\Psr\Log\NullLogger` (although this is not advisable)
  - **[BC]** `\Scoutapm\Agent::__construct` is now private
    - Use the named constructor `\Scoutapm\Agent::fromConfig()` instead
- - **[BC]** Third parameter for `\Scoutapm\Agent::fromConfig` is now a `\Psr\SimpleCache\CacheInterface` implementation (`null`-able)
+ - **[BC]** Third parameter for `\Scoutapm\Agent::fromConfig` is now a `\Psr\SimpleCache\CacheInterface` implementation (`null`-able) (#123)
 
 ### Removed
  - **[BC]** `\Scoutapm\Agent::fromDefaults()` named constructor was removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,33 @@
 # Changelog
 
-## Pending
+## Pending - [2.0.0]
+
+### Added
+
+ - Added `language_version` key to be sent with metadata (#110)
+ - Added more debug logging to isolate issues easier (#111, #115, #117)
+ - Added detection of `musl` by checking if `/etc/alpine-release` exists (#118)
+ - **[BC]** Third parameter for `\Scoutapm\Agent::fromConfig` is now a `\Psr\SimpleCache\CacheInterface` implementation (`null`-able) (#123)
+   - Unlikely to affect most customers, unless they explicitly provided a `\Scoutapm\Connector\Connector` implementation to the `Agent`
 
 ### Changed
 
- - Added `language_version` key to be sent with metadata (#110)
- - Added more debug logging to isolate issues easier (#111, #115)
- - Added detection of `musl` by checking if `/etc/alpine-release` exists (#118)
  - **[BC]** `\Scoutapm\Connector\Connector::sendCommand` now returns `string` not `bool`
+   - Unlikely to affect most customers, unless they wrote a custom implementation of `\Scoutapm\Connector\Connector`
  - **[BC]** `\Scoutapm\Agent::fromConfig()` second parameter for a `\Psr\Log\LoggerInterface` implementation is no longer optional
    - You should pass in an implementation of `\Psr\Log\LoggerInterface` as the second parameter
    - If you do not want logging, you can use `\Psr\Log\NullLogger` (although this is not advisable)
- - **[BC]** `\Scoutapm\Agent::__construct` is now private
-   - Use the named constructor `\Scoutapm\Agent::fromConfig()` instead
- - **[BC]** Third parameter for `\Scoutapm\Agent::fromConfig` is now a `\Psr\SimpleCache\CacheInterface` implementation (`null`-able) (#123)
+ - Updated core agent version to `1.2.6` (#127)
+
+### Fixed
+
+ - Fixing bug with instrumentation delivery to dashboard (#126)
+ - Handle warning that was escaping from `socket_connect` (#124)
 
 ### Removed
+
+ - **[BC]** `\Scoutapm\Agent::__construct` is now private
+   - Use the named constructor `\Scoutapm\Agent::fromConfig()` instead
  - **[BC]** `\Scoutapm\Agent::fromDefaults()` named constructor was removed
    - For exactly matching behaviour, use `::fromConfig(new \Scoutapm\Config(), new \Psr\Log\NullLogger())`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
    - If you do not want logging, you can use `\Psr\Log\NullLogger` (although this is not advisable)
  - **[BC]** `\Scoutapm\Agent::__construct` is now private
    - Use the named constructor `\Scoutapm\Agent::fromConfig()` instead
+ - **[BC]** Third parameter for `\Scoutapm\Agent::fromConfig` is now a `\Psr\SimpleCache\CacheInterface` implementation (`null`-able)
 
 ### Removed
  - **[BC]** `\Scoutapm\Agent::fromDefaults()` named constructor was removed

--- a/README.md
+++ b/README.md
@@ -101,11 +101,13 @@ implementation when creating the agent:
 
 ```php
 use Doctrine\Common\Cache\RedisCache;
+use Psr\Log\LoggerInterface;
 use Roave\DoctrineSimpleCache\SimpleCacheAdapter;
 use Scoutapm\Agent;
 use Scoutapm\Config;
 use Scoutapm\Config\ConfigKey;
 
+/** @var LoggerInterface $psrLoggerImplementation */
 $yourPsrSimpleCacheImplementation = new SimpleCacheAdapter(new RedisCache());
 
 $agent = Agent::fromConfig(
@@ -114,7 +116,7 @@ $agent = Agent::fromConfig(
         ConfigKey::APPLICATION_KEY => 'your scout key',
         ConfigKey::MONITORING_ENABLED => true,
     ]),
-    null, // or a logging implementation
+    $psrLoggerImplementation,
     $yourPsrSimpleCacheImplementation
 );
 ```

--- a/README.md
+++ b/README.md
@@ -93,6 +93,32 @@ With the extension enabled, specific IO-bound functions in PHP are monitored, fo
 
 Alternatively, you can [install from source](https://github.com/scoutapp/scout-apm-php-ext).
 
+## Enable caching for Scout
+
+Due to PHP's stateless and "shared-nothing" architecture, the Scout library performs some checks (such as sending some
+metadata about the running system) on every request. These can be eliminated by giving Scout a PSR-16 (Simple Cache)
+implementation when creating the agent:
+
+```php
+use Doctrine\Common\Cache\RedisCache;
+use Roave\DoctrineSimpleCache\SimpleCacheAdapter;
+use Scoutapm\Agent;
+use Scoutapm\Config;
+use Scoutapm\Config\ConfigKey;
+
+$yourPsrSimpleCacheImplementation = new SimpleCacheAdapter(new RedisCache());
+
+$agent = Agent::fromConfig(
+    Config::fromArray([
+        ConfigKey::APPLICATION_NAME => 'Your application name',
+        ConfigKey::APPLICATION_KEY => 'your scout key',
+        ConfigKey::MONITORING_ENABLED => true,
+    ]),
+    null, // or a logging implementation
+    $yourPsrSimpleCacheImplementation
+);
+```
+
 ## Documentation
 
 For full installation and troubleshooting documentation, visit our [help site](http://docs.scoutapm.com/#php-agent).

--- a/composer.json
+++ b/composer.json
@@ -8,11 +8,12 @@
     "require": {
         "php": ">=7.1.0,<7.5.0",
         "ext-json": "*",
+        "ext-openssl": "*",
         "ext-sockets": "*",
         "ext-zlib": "*",
-        "ext-openssl": "*",
         "ocramius/package-versions": "^1.4",
         "psr/log": "^1.0",
+        "psr/simple-cache": "^1.0",
         "ralouphie/getallheaders": "^2.0.5|^3.0",
         "ramsey/uuid": "^3.0",
         "webmozart/assert": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,11 @@
         "webmozart/assert": "^1.0"
     },
     "require-dev": {
-        "psr/log": "^1.1",
         "doctrine/coding-standard": "^6.0",
         "monolog/monolog": "^1.24",
         "phpunit/phpunit": "^7.5",
+        "psr/log": "^1.1",
+        "roave/doctrine-simplecache": "^2.2",
         "spatie/phpunit-watcher": "^1.8",
         "vimeo/psalm": "^3.4"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bed9f83242ed070cff9cdc19323fde26",
+    "content-hash": "46926a2669200bf37d30762d3feb2d86",
     "packages": [
         {
             "name": "ocramius/package-versions",
@@ -843,6 +843,88 @@
                 "tests"
             ],
             "time": "2018-10-26T13:21:45+00:00"
+        },
+        {
+            "name": "doctrine/cache",
+            "version": "1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/cache.git",
+                "reference": "382e7f4db9a12dc6c19431743a2b096041bcdd62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/382e7f4db9a12dc6c19431743a2b096041bcdd62",
+                "reference": "382e7f4db9a12dc6c19431743a2b096041bcdd62",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.1"
+            },
+            "conflict": {
+                "doctrine/common": ">2.2,<2.4"
+            },
+            "require-dev": {
+                "alcaeus/mongo-php-adapter": "^1.1",
+                "doctrine/coding-standard": "^6.0",
+                "mongodb/mongodb": "^1.1",
+                "phpunit/phpunit": "^7.0",
+                "predis/predis": "~1.0"
+            },
+            "suggest": {
+                "alcaeus/mongo-php-adapter": "Required to use legacy MongoDB driver"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Cache library is a popular cache implementation that supports many different drivers such as redis, memcache, apc, mongodb and others.",
+            "homepage": "https://www.doctrine-project.org/projects/cache.html",
+            "keywords": [
+                "abstraction",
+                "apcu",
+                "cache",
+                "caching",
+                "couchdb",
+                "memcached",
+                "php",
+                "redis",
+                "xcache"
+            ],
+            "time": "2019-11-29T15:36:20+00:00"
         },
         {
             "name": "doctrine/coding-standard",
@@ -2205,6 +2287,57 @@
                 "writable"
             ],
             "time": "2019-01-01T16:15:09+00:00"
+        },
+        {
+            "name": "roave/doctrine-simplecache",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Roave/DoctrineSimpleCache.git",
+                "reference": "1ad494f47812cf63226ad60bb3b47bb37a2771cd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Roave/DoctrineSimpleCache/zipball/1ad494f47812cf63226ad60bb3b47bb37a2771cd",
+                "reference": "1ad494f47812cf63226ad60bb3b47bb37a2771cd",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/cache": "^1.7",
+                "php": "^7.1,<7.4",
+                "psr/simple-cache": "^1.0"
+            },
+            "provide": {
+                "psr/simple-cache-implementation": "1.0"
+            },
+            "require-dev": {
+                "cache/integration-tests": "dev-master#05f9717",
+                "cache/tag-interop": "dev-master#992b7ed",
+                "infection/infection": "^0.11.2",
+                "phpunit/phpunit": "^6.5 || ^7.0",
+                "symfony/console": "^3.4 || ^4.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Roave\\DoctrineSimpleCache\\": "src/"
+                },
+                "files": [
+                    "namespace-bc-aliases.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "James Titcumb",
+                    "email": "james@asgrim.com"
+                }
+            ],
+            "description": "Doctrine Cache adapter for PSR-16 Simple Cache",
+            "time": "2019-01-24T09:43:58+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d95ca739c9986f6dabf5f1769e4c36b2",
+    "content-hash": "bed9f83242ed070cff9cdc19323fde26",
     "packages": [
         {
             "name": "ocramius/package-versions",
@@ -147,6 +147,54 @@
                 "psr-3"
             ],
             "time": "2018-11-20T15:27:04+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "time": "2017-10-23T01:57:42+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -3496,9 +3544,9 @@
     "platform": {
         "php": ">=7.1.0,<7.5.0",
         "ext-json": "*",
+        "ext-openssl": "*",
         "ext-sockets": "*",
-        "ext-zlib": "*",
-        "ext-openssl": "*"
+        "ext-zlib": "*"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -8,13 +8,14 @@ use Closure;
 use DateTimeImmutable;
 use DateTimeZone;
 use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
 use Psr\SimpleCache\CacheInterface;
 use Scoutapm\Cache\DevNullCache;
 use Scoutapm\Config\ConfigKey;
 use Scoutapm\Config\IgnoredEndpoints;
 use Scoutapm\Connector\Connector;
 use Scoutapm\Connector\Exception\FailedToConnect;
+use Scoutapm\Connector\Exception\FailedToSendCommand;
+use Scoutapm\Connector\Exception\NotConnected;
 use Scoutapm\Connector\SocketConnector;
 use Scoutapm\CoreAgent\AutomaticDownloadAndLaunchManager;
 use Scoutapm\CoreAgent\Downloader;
@@ -113,14 +114,14 @@ final class Agent implements ScoutApmAgent
         return new SocketConnector($config->get(ConfigKey::CORE_AGENT_SOCKET_PATH));
     }
 
-    public static function fromConfig(Config $config, LoggerInterface $logger, ?Connector $connector = null) : self
+    public static function fromConfig(Config $config, LoggerInterface $logger, ?CacheInterface $cache = null, ?Connector $connector = null) : self
     {
         return new self(
             $config,
             $connector ?? self::createConnectorFromConfig($config),
             $logger,
             new PotentiallyAvailableExtensionCapabilities(),
-            new DevNullCache()
+            $cache ?? new DevNullCache()
         );
     }
 

--- a/src/Cache/DevNullCache.php
+++ b/src/Cache/DevNullCache.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scoutapm\Cache;
+
+use Psr\SimpleCache\CacheInterface;
+use Traversable;
+use function array_map;
+use function is_array;
+use function iterator_to_array;
+
+/** @internal */
+final class DevNullCache implements CacheInterface
+{
+    /** @inheritDoc */
+    public function get($key, $default = null)
+    {
+        return $default;
+    }
+
+    /** @inheritDoc */
+    public function set($key, $value, $ttl = null) : bool
+    {
+        return true;
+    }
+
+    /** @inheritDoc */
+    public function delete($key) : bool
+    {
+        return true;
+    }
+
+    /** @inheritDoc */
+    public function clear() : bool
+    {
+        return true;
+    }
+
+    /** @inheritDoc */
+    public function getMultiple($keys, $default = null)
+    {
+        /** @var array|Traversable $keys */
+        if (is_array($keys)) {
+            $keysAsArray = $keys;
+        } else {
+            $keysAsArray = iterator_to_array($keys, false);
+        }
+
+        return array_map(
+            /** @return mixed */
+            function (string $key) use ($default) {
+                return $this->get($key, $default);
+            },
+            $keysAsArray
+        );
+    }
+
+    /** @inheritDoc */
+    public function setMultiple($values, $ttl = null) : bool
+    {
+        return true;
+    }
+
+    /** @inheritDoc */
+    public function deleteMultiple($keys) : bool
+    {
+        return true;
+    }
+
+    /** @inheritDoc */
+    public function has($key) : bool
+    {
+        return false;
+    }
+}

--- a/src/Cache/DevNullCache.php
+++ b/src/Cache/DevNullCache.php
@@ -6,6 +6,7 @@ namespace Scoutapm\Cache;
 
 use Psr\SimpleCache\CacheInterface;
 use Traversable;
+use function array_combine;
 use function array_map;
 use function is_array;
 use function iterator_to_array;
@@ -47,12 +48,15 @@ final class DevNullCache implements CacheInterface
             $keysAsArray = iterator_to_array($keys, false);
         }
 
-        return array_map(
-            /** @return mixed */
-            function (string $key) use ($default) {
-                return $this->get($key, $default);
-            },
-            $keysAsArray
+        return array_combine(
+            $keysAsArray,
+            array_map(
+                /** @return mixed */
+                function (string $key) use ($default) {
+                    return $this->get($key, $default);
+                },
+                $keysAsArray
+            )
         );
     }
 

--- a/tests/Integration/AgentTest.php
+++ b/tests/Integration/AgentTest.php
@@ -75,7 +75,7 @@ final class AgentTest extends TestCase
 
         $_SERVER['REQUEST_URI'] = '/fake-path';
 
-        $agent = Agent::fromConfig($config, $this->logger, $connector);
+        $agent = Agent::fromConfig($config, $this->logger, null, $connector);
 
         $agent->connect();
 

--- a/tests/Unit/Cache/DevNullCacheTest.php
+++ b/tests/Unit/Cache/DevNullCacheTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scoutapm\UnitTests\Cache;
+
+use PHPUnit\Framework\TestCase;
+use Psr\SimpleCache\InvalidArgumentException;
+use Scoutapm\Cache\DevNullCache;
+use function uniqid;
+
+/** @covers \Scoutapm\Cache\DevNullCache */
+final class DevNullCacheTest extends TestCase
+{
+    /** @throws InvalidArgumentException */
+    public function testCacheGetReturnsDefaultValueAfterSet() : void
+    {
+        $cache        = new DevNullCache();
+        $someKey      = uniqid('someKey', true);
+        $defaultValue = uniqid('defaultValue', true);
+
+        self::assertTrue($cache->set($someKey, uniqid('actualValue', true)));
+
+        self::assertFalse($cache->has($someKey));
+        self::assertSame($defaultValue, $cache->get($someKey, $defaultValue));
+    }
+
+    /** @throws InvalidArgumentException */
+    public function testCacheGetReturnsNullAfterSetWhenNoDefaultGiven() : void
+    {
+        $cache   = new DevNullCache();
+        $someKey = uniqid('someKey', true);
+
+        self::assertTrue($cache->set($someKey, uniqid('actualValue', true)));
+
+        self::assertFalse($cache->has($someKey));
+        self::assertNull($cache->get($someKey));
+    }
+
+    /** @throws InvalidArgumentException */
+    public function testCacheGetReturnsDefaultValueAfterDelete() : void
+    {
+        $cache        = new DevNullCache();
+        $someKey      = uniqid('someKey', true);
+        $defaultValue = uniqid('defaultValue', true);
+
+        self::assertTrue($cache->set($someKey, uniqid('actualValue', true)));
+        self::assertTrue($cache->delete($someKey));
+
+        self::assertFalse($cache->has($someKey));
+        self::assertSame($defaultValue, $cache->get($someKey, $defaultValue));
+    }
+
+    /** @throws InvalidArgumentException */
+    public function testCacheGetReturnsDefaultValueAfterClear() : void
+    {
+        $cache        = new DevNullCache();
+        $someKey      = uniqid('someKey', true);
+        $defaultValue = uniqid('defaultValue', true);
+
+        self::assertTrue($cache->set($someKey, uniqid('actualValue', true)));
+        self::assertTrue($cache->clear());
+
+        self::assertFalse($cache->has($someKey));
+        self::assertSame($defaultValue, $cache->get($someKey, $defaultValue));
+    }
+
+    /** @throws InvalidArgumentException */
+    public function testCacheGetMultipleReturnsDefaultValueAfterSetMultiple() : void
+    {
+        $cache        = new DevNullCache();
+        $someKey      = uniqid('someKey', true);
+        $defaultValue = uniqid('defaultValue', true);
+
+        self::assertTrue($cache->setMultiple([$someKey => uniqid('actualValue', true)]));
+
+        self::assertFalse($cache->has($someKey));
+        self::assertEquals([$someKey => $defaultValue], $cache->getMultiple([$someKey], $defaultValue));
+    }
+
+    /** @throws InvalidArgumentException */
+    public function testCacheGetMultipleReturnsNullAfterSetMultipleWithNoDefaultValue() : void
+    {
+        $cache   = new DevNullCache();
+        $someKey = uniqid('someKey', true);
+
+        self::assertTrue($cache->setMultiple([$someKey => uniqid('actualValue', true)]));
+
+        self::assertFalse($cache->has($someKey));
+        self::assertEquals([$someKey => null], $cache->getMultiple([$someKey]));
+    }
+
+    /** @throws InvalidArgumentException */
+    public function testCacheGetMultipleReturnsDefaultValueAfterDeleteMultiple() : void
+    {
+        $cache        = new DevNullCache();
+        $someKey      = uniqid('someKey', true);
+        $defaultValue = uniqid('defaultValue', true);
+
+        self::assertTrue($cache->setMultiple([$someKey => uniqid('actualValue', true)]));
+        self::assertTrue($cache->deleteMultiple([$someKey]));
+
+        self::assertFalse($cache->has($someKey));
+        self::assertEquals([$someKey => $defaultValue], $cache->getMultiple([$someKey], $defaultValue));
+    }
+}


### PR DESCRIPTION
Fixes #100

Note: BC break here is the addition of the `Cache` parameter - it's `null`able and unlikely to affect anyone unless they implemented a custom `Connector` (unlikely)

#### Todo:

 - [x] Documentation on how to enable a cache
 - [x] Only cache sending of metadata, not registration too
 - [x] Rebase after #117 (since API improvements will conflict)