### PR TITLE
Fix warning on failed socket_connect

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,10 @@
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutTodoAnnotatedTests="true"
     forceCoversAnnotation="true"
+    convertWarningsToExceptions="false"
+    convertErrorsToExceptions="false"
+    convertNoticesToExceptions="false"
+    convertDeprecationsToExceptions="false"
 >
     <testsuites>
         <testsuite name="unit">
@@ -20,6 +24,7 @@
     </testsuites>
     <php>
         <ini name="error_reporting" value="E_ALL" />
+        <ini name="display_errors" value="On" />
     </php>
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">


### PR DESCRIPTION
Didn't notice this before because phpunit swallows warnings etc. and converts them to exceptions, which of course get caught by the `catch` and operates as expected. However, outside of phpunit, these warnings were bubbling up. 

