### PR TITLE
Update CoreAgent version to 1.2.6, with several bug fixes:

### DIFF
--- a/src/Config/Source/DefaultSource.php
+++ b/src/Config/Source/DefaultSource.php
@@ -50,7 +50,7 @@ final class DefaultSource implements ConfigSource
             ConfigKey::CORE_AGENT_DIRECTORY => '/tmp/scout_apm_core',
             ConfigKey::CORE_AGENT_DOWNLOAD_ENABLED => true,
             ConfigKey::CORE_AGENT_LAUNCH_ENABLED => true,
-            ConfigKey::CORE_AGENT_VERSION => 'v1.2.4',
+            ConfigKey::CORE_AGENT_VERSION => 'v1.2.6',
             ConfigKey::CORE_AGENT_DOWNLOAD_URL => 'https://s3-us-west-1.amazonaws.com/scout-public-downloads/apm_core_agent/release',
             ConfigKey::CORE_AGENT_PERMISSIONS => 0777,
             ConfigKey::MONITORING_ENABLED => false,


### PR DESCRIPTION
(from CA's changelog)

[1.2.6] 2019-12-03

Fixed:

* Use SQL derived names in SpanTraces (#97)

[1.2.5] 2019-12-02

Added:

* Autoclose running spans when request finishes (#93)
* Rate Limit AppServerLoad metadata (#94)
* Add `language_version` key to AppServerLoad metadata (#95)

Fixed:

* Prevent errors if AppServerLoad metadata is not set (#92)