### PR TITLE
Temporarily remove instructions for Native Ext

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,22 +77,6 @@ $agent = Agent::fromConfig(
 );
 ```
 
-## Monitoring of PHP internal functions
-
-You can enable additional monitoring of internal PHP function executions to measure time taken there. To do so, you need
-to install and enable the `scoutapm` PHP extension from PECL, for example:
-
-```bash
-$ sudo pecl install scoutapm
-```
-
-You may need to add `zend_extension=scoutapm.so` into your `php.ini` to enable the extension.
-
-With the extension enabled, specific IO-bound functions in PHP are monitored, for example `file_get_contents`,
-`file_put_contents`, `PDO->exec` and so on.
-
-Alternatively, you can [install from source](https://github.com/scoutapp/scout-apm-php-ext).
-
 ## Enable caching for Scout
 
 Due to PHP's stateless and "shared-nothing" architecture, the Scout library performs some checks (such as sending some


### PR DESCRIPTION
The native extension exposes a bug further down the agent stack that causes missing data. Removing the recommendation to install it for now, and will readd when the bug is fixed.