### PR TITLE
Correctly handle warnings when reading manifest and cleaning download locks

### DIFF
--- a/src/CoreAgent/Downloader.php
+++ b/src/CoreAgent/Downloader.php
@@ -8,6 +8,7 @@ use PharData;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Throwable;
+use Webmozart\Assert\Assert;
 use function basename;
 use function copy;
 use function dirname;
@@ -149,7 +150,16 @@ class Downloader
 
     private function cleanStaleDownloadLock() : void
     {
+        if (! file_exists($this->download_lock_path)) {
+            $this->logger->debug(sprintf('Lock path "%s" did not exist, nothing to clean', $this->download_lock_path));
+
+            return;
+        }
+
         try {
+            Assert::fileExists($this->download_lock_path);
+            Assert::file($this->download_lock_path);
+
             $delta = time() - filectime($this->download_lock_path);
             if ($delta > $this->stale_download_secs) {
                 $this->logger->debug(sprintf('Clearing stale download lock file "%s".', $this->download_lock_path));

--- a/src/CoreAgent/Manifest.php
+++ b/src/CoreAgent/Manifest.php
@@ -7,6 +7,7 @@ namespace Scoutapm\CoreAgent;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Throwable;
+use Webmozart\Assert\Assert;
 use const JSON_ERROR_NONE;
 use function file_get_contents;
 use function json_decode;
@@ -54,6 +55,10 @@ class Manifest
     private function parse() : void
     {
         $this->logger->info(sprintf('Parsing Core Agent Manifest at "%s"', $this->manifestPath));
+
+        Assert::fileExists($this->manifestPath);
+        Assert::file($this->manifestPath);
+        Assert::readable($this->manifestPath);
 
         $raw  = file_get_contents($this->manifestPath);
         $json = json_decode($raw, true); // decode the JSON into an associative array


### PR DESCRIPTION
Fixes #129 