### PR TITLE
Added PHP 7.4 support to CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 env:
   - DEPENDENCIES="--prefer-lowest --prefer-stable" PHP=""
@@ -25,12 +26,12 @@ script:
 jobs:
   include:
     - stage: Check coding standards
-      php: 7.3
+      php: 7.4
       env: DEPENDENCIES="" PHP=""
       script: vendor/bin/phpcs
 
     - stage: Run static analysis check
-      php: 7.3
+      php: 7.4
       env: DEPENDENCIES="" PHP=""
       script: vendor/bin/psalm
 


### PR DESCRIPTION
Since we support it in `composer.json` (`"php": ">=7.1.0,<7.5.0",`) we should probably have this in our build...