### PR TITLE
Catch exceptions raised whilst sending metadata

### DIFF
--- a/tests/Unit/AgentTest.php
+++ b/tests/Unit/AgentTest.php
@@ -296,7 +296,7 @@ final class AgentTest extends TestCase
             $connector
         );
 
-        $connector->method('connected')->wilLReturn(true);
+        $connector->method('connected')->willReturn(true);
 
         $connector->expects(self::at(1))
             ->method('sendCommand')


### PR DESCRIPTION
If we catch all exceptions raised whilst gathering/sending metadata, we can log it and continue to send the actual request. Exceptions should not be bubbling up, especially for something trivial.