### PR TITLE
Only tag args if there are any

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -30,6 +30,7 @@ use Scoutapm\Extension\ExtentionCapabilities;
 use Scoutapm\Extension\PotentiallyAvailableExtensionCapabilities;
 use Scoutapm\Logger\FilteredLogLevelDecorator;
 use Throwable;
+use function count;
 use function is_string;
 use function json_encode;
 use function sprintf;
@@ -213,7 +214,13 @@ final class Agent implements ScoutApmAgent
 
         foreach ($this->phpExtension->getCalls() as $recordedCall) {
             $callSpan = $this->request->startSpan($recordedCall->functionName(), $recordedCall->timeEntered());
-            $callSpan->tag(Tag::TAG_ARGUMENTS, $recordedCall->filteredArguments());
+
+            $arguments = $recordedCall->filteredArguments();
+
+            if (count($arguments) > 0) {
+                $callSpan->tag(Tag::TAG_ARGUMENTS, $arguments);
+            }
+
             $this->request->stopSpan($recordedCall->timeExited());
         }
     }

--- a/src/Events/Tag/Tag.php
+++ b/src/Events/Tag/Tag.php
@@ -12,7 +12,7 @@ use function microtime;
 abstract class Tag implements Command
 {
     public const TAG_STACK_TRACE  = 'stack';
-    public const TAG_ARGUMENTS    = 'desc';
+    public const TAG_ARGUMENTS    = 'args';
     public const TAG_MEMORY_DELTA = 'memory_delta';
     public const TAG_REQUEST_PATH = 'path';
 

--- a/src/Extension/RecordedCall.php
+++ b/src/Extension/RecordedCall.php
@@ -84,7 +84,8 @@ final class RecordedCall
 
     /**
      * We should never return the full set of arguments, only specific arguments for specific functions. This is to
-     * avoid potentially spilling personally identifiable information.
+     * avoid potentially spilling personally identifiable information. Another reason to only return specific arguments
+     * is to avoid sending loads of data unnecessarily.
      *
      * @return mixed[]
      */

--- a/tests/Integration/AgentTest.php
+++ b/tests/Integration/AgentTest.php
@@ -148,7 +148,7 @@ final class AgentTest extends TestCase
 
                     if (TestHelper::scoutApmExtensionAvailable()) {
                         $fileGetContentsSpanId = $this->assertUnserializedCommandContainsPayload('StartSpan', ['operation' => 'file_get_contents', 'parent_id' => $controllerSpanId], next($commands), 'span_id');
-                        $this->assertUnserializedCommandContainsPayload('TagSpan', ['span_id' => $fileGetContentsSpanId, 'tag' => 'desc', 'value' => ['url' => __FILE__]], next($commands), null);
+                        $this->assertUnserializedCommandContainsPayload('TagSpan', ['span_id' => $fileGetContentsSpanId, 'tag' => 'args', 'value' => ['url' => __FILE__]], next($commands), null);
                         $this->assertUnserializedCommandContainsPayload('StopSpan', ['span_id' => $fileGetContentsSpanId], next($commands), null);
                     }
 
@@ -156,7 +156,7 @@ final class AgentTest extends TestCase
 
                     if (TestHelper::scoutApmExtensionAvailable()) {
                         $fileGetContentsSpanId = $this->assertUnserializedCommandContainsPayload('StartSpan', ['operation' => 'file_get_contents', 'parent_id' => $fooSpanId], next($commands), 'span_id');
-                        $this->assertUnserializedCommandContainsPayload('TagSpan', ['span_id' => $fileGetContentsSpanId, 'tag' => 'desc', 'value' => ['url' => __FILE__]], next($commands), null);
+                        $this->assertUnserializedCommandContainsPayload('TagSpan', ['span_id' => $fileGetContentsSpanId, 'tag' => 'args', 'value' => ['url' => __FILE__]], next($commands), null);
                         $this->assertUnserializedCommandContainsPayload('StopSpan', ['span_id' => $fileGetContentsSpanId], next($commands), null);
                     }
 
@@ -164,7 +164,7 @@ final class AgentTest extends TestCase
 
                     if (TestHelper::scoutApmExtensionAvailable()) {
                         $fileGetContentsSpanId = $this->assertUnserializedCommandContainsPayload('StartSpan', ['operation' => 'file_get_contents', 'parent_id' => $barSpanId], next($commands), 'span_id');
-                        $this->assertUnserializedCommandContainsPayload('TagSpan', ['span_id' => $fileGetContentsSpanId, 'tag' => 'desc', 'value' => ['url' => __FILE__]], next($commands), null);
+                        $this->assertUnserializedCommandContainsPayload('TagSpan', ['span_id' => $fileGetContentsSpanId, 'tag' => 'args', 'value' => ['url' => __FILE__]], next($commands), null);
                         $this->assertUnserializedCommandContainsPayload('StopSpan', ['span_id' => $fileGetContentsSpanId], next($commands), null);
                     }
 
@@ -176,7 +176,7 @@ final class AgentTest extends TestCase
 
                     if (TestHelper::scoutApmExtensionAvailable()) {
                         $fileGetContentsSpanId = $this->assertUnserializedCommandContainsPayload('StartSpan', ['operation' => 'file_get_contents', 'parent_id' => $controllerSpanId], next($commands), 'span_id');
-                        $this->assertUnserializedCommandContainsPayload('TagSpan', ['span_id' => $fileGetContentsSpanId, 'tag' => 'desc', 'value' => ['url' => __FILE__]], next($commands), null);
+                        $this->assertUnserializedCommandContainsPayload('TagSpan', ['span_id' => $fileGetContentsSpanId, 'tag' => 'args', 'value' => ['url' => __FILE__]], next($commands), null);
                         $this->assertUnserializedCommandContainsPayload('StopSpan', ['span_id' => $fileGetContentsSpanId], next($commands), null);
                     }
 


### PR DESCRIPTION
From PHP internal function calls recorded by the extension, only tag the arguments if there are any interesting arguments to be tagged.