### PR TITLE
Wrap socket calls with error handler

### DIFF
--- a/src/Connector/SocketConnector.php
+++ b/src/Connector/SocketConnector.php
@@ -113,22 +113,22 @@ final class SocketConnector implements Connector
         // Socket error is a global state, so we must reset to a known state first...
         socket_clear_error($this->socket);
 
-        if (socket_send($this->socket, pack('N', $size), 4, 0) === false) {
+        if (@socket_send($this->socket, pack('N', $size), 4, 0) === false) {
             throw Exception\FailedToSendCommand::writingMessageSizeToSocket($message, $this->socket, $this->socketPath);
         }
 
-        if (socket_send($this->socket, $serializedJsonString, $size, 0) === false) {
+        if (@socket_send($this->socket, $serializedJsonString, $size, 0) === false) {
             throw Exception\FailedToSendCommand::writingMessageContentToSocket($message, $this->socket, $this->socketPath);
         }
 
         // Read the response back and drop it. Needed for socket liveness
-        $responseLength = socket_read($this->socket, 4);
+        $responseLength = @socket_read($this->socket, 4);
 
         if ($responseLength === false) {
             throw Exception\FailedToSendCommand::readingResponseSizeFromSocket($message, $this->socket, $this->socketPath);
         }
 
-        $dataRead = socket_read($this->socket, unpack('N', $responseLength)[1]);
+        $dataRead = @socket_read($this->socket, unpack('N', $responseLength)[1]);
 
         if ($dataRead === false) {
             throw Exception\FailedToSendCommand::readingResponseContentFromSocket($message, $this->socket, $this->socketPath);

--- a/tests/Unit/Connector/SocketConnectorTest.php
+++ b/tests/Unit/Connector/SocketConnectorTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scoutapm\UnitTests\Connector;
+
+use PHPUnit\Framework\TestCase;
+use Scoutapm\Connector\Exception\FailedToConnect;
+use Scoutapm\Connector\SocketConnector;
+
+/** @covers \Scoutapm\Connector\SocketConnector */
+final class SocketConnectorTest extends TestCase
+{
+    public function testExceptionIsRaisedWhenConnectingToNonExistentSocket() : void
+    {
+        $connector = new SocketConnector('/path/does/not/exist');
+
+        $this->expectException(FailedToConnect::class);
+        $this->expectExceptionMessage('socket_connect(): unable to connect [2]: No such file or directory');
+        $connector->connect();
+    }
+}


### PR DESCRIPTION
Fixes #138 

Turns out, actually the errors raised with `socket_read`/`socket_send` calls are already correctly handled with `socket_last_error`, so we just need to suppress the errors from bubbling up with the `@` operator. Testing this class is going to be very tricky however, but we can delay that for #64 as a future improvement I think.