### PR TITLE
Expose new ScoutApmAgent endpoint to start a new request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## Pending - [2.1.2]
+## Pending - [3.0.0]
+
+ - [BC] Added new method `Scoutapm\ScoutApmAgent::startNewRequest` (#148)
+   - implementors of `Scoutapm\ScoutApmAgent` will now need to implement this new method
 
 ## [2.1.1] 2019-12-17
 

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -99,7 +99,7 @@ final class Agent implements ScoutApmAgent
             $this->warnIfConfigValueIsNotSet(ConfigKey::APPLICATION_KEY);
         }
 
-        $this->request = new Request();
+        $this->startNewRequest();
 
         $this->ignoredEndpoints = new IgnoredEndpoints($configuration->get(ConfigKey::IGNORED_ENDPOINTS));
     }
@@ -339,7 +339,7 @@ final class Agent implements ScoutApmAgent
                 $this->connector->sendCommand($this->request)
             ));
 
-            $this->request = new Request();
+            $this->startNewRequest();
 
             return true;
         } catch (NotConnected $notConnected) {
@@ -351,6 +351,12 @@ final class Agent implements ScoutApmAgent
 
             return false;
         }
+    }
+
+    /** {@inheritDoc} */
+    public function startNewRequest() : void
+    {
+        $this->request = new Request();
     }
 
     private function registerIfRequired() : void

--- a/src/ScoutApmAgent.php
+++ b/src/ScoutApmAgent.php
@@ -75,6 +75,11 @@ interface ScoutApmAgent
     public function send() : bool;
 
     /**
+     * Clears any currently recorded request data/spans, and start a new request.
+     */
+    public function startNewRequest() : void;
+
+    /**
      * You probably don't need this, it's useful in testing
      *
      * @internal

--- a/tests/Unit/AgentTest.php
+++ b/tests/Unit/AgentTest.php
@@ -397,4 +397,19 @@ final class AgentTest extends TestCase
         $agent->send();
         $agent->send();
     }
+
+    public function testRequestIsResetAfterStartingANewRequest() : void
+    {
+        $agent = $this->agentFromConfigArray([
+            ConfigKey::APPLICATION_NAME => 'My test app',
+            ConfigKey::APPLICATION_KEY => uniqid('applicationKey', true),
+            ConfigKey::MONITORING_ENABLED => true,
+        ]);
+
+        $requestBeforeReset = $agent->getRequest();
+
+        $agent->startNewRequest();
+
+        self::assertNotSame($requestBeforeReset, $agent->getRequest());
+    }
 }


### PR DESCRIPTION
Needed to implement scoutapp/scout-apm-laravel#35 properly.