### PR TITLE
Added ability to disable instrumentation by name

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -32,6 +32,8 @@ use Scoutapm\Extension\Version;
 use Scoutapm\Logger\FilteredLogLevelDecorator;
 use Throwable;
 use function count;
+use function in_array;
+use function is_array;
 use function is_string;
 use function json_encode;
 use function sprintf;
@@ -320,6 +322,16 @@ final class Agent implements ScoutApmAgent
     {
         $this->request   = null;
         $this->isIgnored = true;
+    }
+
+    /** {@inheritDoc} */
+    public function shouldInstrument(string $functionality) : bool
+    {
+        $disabledInstruments = $this->config->get(ConfigKey::DISABLED_INSTRUMENTS);
+
+        return $disabledInstruments === null
+            || ! is_array($disabledInstruments)
+            || ! in_array($functionality, $disabledInstruments, true);
     }
 
     /** {@inheritDoc} */

--- a/src/Config.php
+++ b/src/Config.php
@@ -49,6 +49,7 @@ class Config
         $this->coercions = [
             ConfigKey::MONITORING_ENABLED => new CoerceBoolean(),
             ConfigKey::IGNORED_ENDPOINTS => new CoerceJson(),
+            ConfigKey::DISABLED_INSTRUMENTS => new CoerceJson(),
         ];
     }
 

--- a/src/Config/ConfigKey.php
+++ b/src/Config/ConfigKey.php
@@ -21,6 +21,7 @@ abstract class ConfigKey
     public const SCM_SUBDIRECTORY            = 'scm_subdirectory';
     public const REVISION_SHA                = 'revision_sha';
     public const HOSTNAME                    = 'hostname';
+    public const DISABLED_INSTRUMENTS        = 'disabled_instruments';
     public const CORE_AGENT_LOG_LEVEL        = 'core_agent_log_level';
     public const CORE_AGENT_LOG_FILE         = 'core_agent_log_file';
     public const CORE_AGENT_CONFIG_FILE      = 'core_agent_config_file';
@@ -52,6 +53,7 @@ abstract class ConfigKey
             self::SCM_SUBDIRECTORY,
             self::REVISION_SHA,
             self::HOSTNAME,
+            self::DISABLED_INSTRUMENTS,
             self::CORE_AGENT_LOG_LEVEL,
             self::CORE_AGENT_LOG_FILE,
             self::CORE_AGENT_CONFIG_FILE,

--- a/src/ScoutApmAgent.php
+++ b/src/ScoutApmAgent.php
@@ -60,6 +60,14 @@ interface ScoutApmAgent
     public function ignore() : void;
 
     /**
+     * Should the instrumentation be enabled for a particular functionality. This checks the `disabled_instruments`
+     * configuration - if an instrumentation is not explicitly disabled, this will return true.
+     *
+     * The list of functionality that can be disabled depends on the library binding being used.
+     */
+    public function shouldInstrument(string $functionality) : bool;
+
+    /**
      * If the automatically determined request URI is incorrect, please report an issue so we can investigate. You may
      * override the automatic determination of the request URI by calling this method.
      *

--- a/tests/Unit/AgentTest.php
+++ b/tests/Unit/AgentTest.php
@@ -345,6 +345,38 @@ final class AgentTest extends TestCase
         self::assertFalse($agent->ignored('/bar'));
     }
 
+    public function testInstrumentationIsNotDisabledWhenNoDisabledInstrumentsConfigured() : void
+    {
+        self::assertTrue(
+            $this->agentFromConfigArray([])
+                ->shouldInstrument('some functionality')
+        );
+    }
+
+    public function testInstrumentationIsNotDisabledWhenDisabledInstrumentsConfigurationIsWrong() : void
+    {
+        self::assertTrue(
+            $this->agentFromConfigArray([ConfigKey::DISABLED_INSTRUMENTS => 'disabled functionality'])
+                ->shouldInstrument('some functionality')
+        );
+    }
+
+    public function testInstrumentationIsNotDisabledWhenDisabledInstrumentsAreConfigured() : void
+    {
+        self::assertTrue(
+            $this->agentFromConfigArray([ConfigKey::DISABLED_INSTRUMENTS => '["disabled functionality"]'])
+                ->shouldInstrument('some functionality')
+        );
+    }
+
+    public function testInstrumentationIsDisabledWhenDisabledInstrumentsAreConfigured() : void
+    {
+        self::assertFalse(
+            $this->agentFromConfigArray([ConfigKey::DISABLED_INSTRUMENTS => '["disabled functionality"]'])
+                ->shouldInstrument('disabled functionality')
+        );
+    }
+
     /** @throws Exception */
     public function testMetadataExceptionsAreLogged() : void
     {


### PR DESCRIPTION
https://github.com/scoutapp/scout-apm-laravel/pull/44#issuecomment-571707936

Updating this in `scout-apm-php` since it is common functionality needed in all agents.