### PR TITLE
Fix memory leaking from cyclic references

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_script:
 
 script:
   - $PHP vendor/bin/phpunit
+  - tests/check-memory-leaks.sh
 
 jobs:
   include:

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -410,6 +410,10 @@ final class Agent implements ScoutApmAgent
     /** {@inheritDoc} */
     public function startNewRequest() : void
     {
+        if ($this->request !== null) {
+            $this->request->cleanUp();
+        }
+
         $this->request = new Request();
     }
 

--- a/src/Connector/Command.php
+++ b/src/Connector/Command.php
@@ -8,4 +8,9 @@ use JsonSerializable;
 
 interface Command extends JsonSerializable
 {
+    /**
+     * __destruct does not work in removing the cyclic references here, so calling this to remove these references
+     * allows GC to unset stuff to ensure it's really removed.
+     */
+    public function cleanUp() : void;
 }

--- a/src/Events/Metadata.php
+++ b/src/Events/Metadata.php
@@ -48,6 +48,11 @@ final class Metadata implements Command
         $this->phpExtension = $phpExtension;
     }
 
+    public function cleanUp() : void
+    {
+        unset($this->timer);
+    }
+
     /**
      * @return array<string, (string|array<int, array<int, string>>|null)>
      */

--- a/src/Events/RegisterMessage.php
+++ b/src/Events/RegisterMessage.php
@@ -25,6 +25,10 @@ final class RegisterMessage implements Command
         $this->apiVersion = $apiVersion;
     }
 
+    public function cleanUp() : void
+    {
+    }
+
     /** @return array<string, array<string, string>> */
     public function jsonSerialize() : array
     {

--- a/src/Events/Request/Request.php
+++ b/src/Events/Request/Request.php
@@ -15,6 +15,7 @@ use Scoutapm\Helper\MemoryUsage;
 use Scoutapm\Helper\RecursivelyCountSpans;
 use Scoutapm\Helper\Timer;
 use function array_key_exists;
+use function array_map;
 use function is_string;
 
 /** @internal */
@@ -47,6 +48,17 @@ class Request implements CommandWithChildren
         $this->startMemory = MemoryUsage::record();
 
         $this->currentCommand = $this;
+    }
+
+    public function cleanUp() : void
+    {
+        array_map(
+            static function (Command $command) : void {
+                $command->cleanUp();
+            },
+            $this->children
+        );
+        unset($this->timer, $this->children, $this->currentCommand, $this->id, $this->startMemory, $this->requestUriOverride);
     }
 
     public function overrideRequestUri(string $newRequestUri) : void

--- a/src/Events/Span/Span.php
+++ b/src/Events/Span/Span.php
@@ -15,6 +15,7 @@ use Scoutapm\Helper\Backtrace;
 use Scoutapm\Helper\RecursivelyCountSpans;
 use Scoutapm\Helper\Timer;
 use function array_filter;
+use function array_map;
 use function strpos;
 
 /** @internal */
@@ -55,6 +56,17 @@ class Span implements CommandWithParent, CommandWithChildren
         $this->requestId = $requestId;
 
         $this->timer = new Timer($override);
+    }
+
+    public function cleanUp() : void
+    {
+        array_map(
+            static function (Command $command) : void {
+                $command->cleanUp();
+            },
+            $this->children
+        );
+        unset($this->id, $this->requestId, $this->parent, $this->children, $this->name, $this->timer);
     }
 
     public function id() : SpanId

--- a/src/Events/Tag/Tag.php
+++ b/src/Events/Tag/Tag.php
@@ -46,6 +46,11 @@ abstract class Tag implements Command
         $this->timestamp = $timestamp;
     }
 
+    public function cleanUp() : void
+    {
+        unset($this->tag, $this->value, $this->requestId, $this->timestamp);
+    }
+
     /**
      * Get the 'key' portion of this Tag
      */

--- a/tests/Integration/AgentTest.php
+++ b/tests/Integration/AgentTest.php
@@ -18,8 +18,6 @@ use function fopen;
 use function function_exists;
 use function getenv;
 use function gethostname;
-use function json_decode;
-use function json_encode;
 use function memory_get_usage;
 use function next;
 use function reset;
@@ -145,7 +143,7 @@ final class AgentTest extends TestCase
 
         self::assertTrue($this->agent->send(), 'Failed to send messages. ' . $this->formatCapturedLogMessages());
 
-        $unserialized = json_decode(json_encode($this->connector->sentMessages), true);
+        $unserialized = $this->connector->sentMessages;
 
         TestHelper::assertUnserializedCommandContainsPayload(
             'Register',

--- a/tests/Integration/AgentTest.php
+++ b/tests/Integration/AgentTest.php
@@ -107,6 +107,9 @@ final class AgentTest extends TestCase
         $this->logger->records        = [];
         $this->logger->recordsByLevel = [];
 
+        // MessageCapturingConnectorDelegator also persists the sent messages in memory for tests, so free that up
+        $this->connector->sentMessages = [];
+
         /**
          * Install https://github.com/BitOne/php-meminfo to get memory analysis here to identify where memory is
          * allocated, then use `bin/analyzer summary /tmp/my_dump_file.json` to show table.

--- a/tests/Integration/MessageCapturingConnectorDelegator.php
+++ b/tests/Integration/MessageCapturingConnectorDelegator.php
@@ -6,6 +6,8 @@ namespace Scoutapm\IntegrationTests;
 
 use Scoutapm\Connector\Command;
 use Scoutapm\Connector\Connector;
+use function json_decode;
+use function json_encode;
 
 final class MessageCapturingConnectorDelegator implements Connector
 {
@@ -32,7 +34,7 @@ final class MessageCapturingConnectorDelegator implements Connector
 
     public function sendCommand(Command $message) : string
     {
-        $this->sentMessages[] = $message;
+        $this->sentMessages[] = json_decode(json_encode($message), true);
 
         return $this->delegate->sendCommand($message);
     }

--- a/tests/check-memory-leaks.sh
+++ b/tests/check-memory-leaks.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+SINGLE=$(RUN_COUNT=1 php isolated-memory-test.php)
+echo "Single execution used: $SINGLE bytes"
+
+MULTIPLE=$(RUN_COUNT=1000 php isolated-memory-test.php)
+echo "1000 executions used: $MULTIPLE bytes"
+
+if [ "$SINGLE" = "$MULTIPLE" ]; then
+  echo "No memory leak detected"
+  exit 0
+else
+  echo "Potential memory leak!"
+  exit 1
+fi

--- a/tests/isolated-memory-test.php
+++ b/tests/isolated-memory-test.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use Psr\Log\Test\TestLogger;
+use Scoutapm\Agent;
+use Scoutapm\Config;
+use Scoutapm\Events\Span\Span;
+use Scoutapm\Extension\PotentiallyAvailableExtensionCapabilities;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$scoutApmKey = getenv('SCOUT_APM_KEY');
+$runCount    = (int) getenv('RUN_COUNT');
+
+if ($scoutApmKey === false || $runCount <= 0) {
+    echo "Try running: \n\n  SCOUT_APM_KEY=abc123 RUN_COUNT=100 php tests/isolated-memory-test.php\n\n";
+    throw new RuntimeException('Set the environment variable SCOUT_APM_KEY to enable this test.');
+}
+
+$config = Config::fromArray([
+    'name' => 'Agent Integration Test',
+    'key' => $scoutApmKey,
+    'monitor' => true,
+]);
+
+$logger = new TestLogger();
+
+$agent = Agent::fromConfig($config, $logger);
+
+$agent->connect();
+
+(new PotentiallyAvailableExtensionCapabilities())->clearRecordedCalls();
+
+$tagSize        = 500000;
+$startingMemory = memory_get_usage();
+for ($i = 1; $i <= $runCount; $i++) {
+    $agent->startNewRequest();
+    $span = $agent->startSpan(sprintf(
+        '%s/%s%d',
+        Span::INSTRUMENT_JOB,
+        'Test Job #',
+        $i
+    ));
+
+    $span->tag('something', str_repeat('a', $tagSize));
+
+    $agent->stopSpan();
+
+    $agent->connect();
+    $agent->send();
+}
+
+$logger->records        = [];
+$logger->recordsByLevel = [];
+
+$used = memory_get_usage() - $startingMemory;
+echo $used . "\n";


### PR DESCRIPTION
Fixes #157 

We use a tree that references itself several places (such as `$parent` and `$children` all over), I think there were "dangling" references left lying around. I've added a `cleanUp` method to any `Command` which basically unsets all its own properties. This seems to have brought down the memory usage significantly after looping. I'm not 100% convinced this fixes everything, and I haven't yet been able to understand why this is necessary at all, so I'd like to get some further insight, perhaps we can come up with a better way to fix this.