### PR TITLE
Use core-agent 1.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 4.2.0 - 2020-03-17
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- [#173](https://github.com/scoutapp/scout-apm-php/pull/173) Updated to use core-agent 1.2.8
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 4.1.0 - 2020-03-05
 
 ### Added

--- a/src/Config/Source/DefaultSource.php
+++ b/src/Config/Source/DefaultSource.php
@@ -50,7 +50,7 @@ final class DefaultSource implements ConfigSource
             ConfigKey::CORE_AGENT_DIRECTORY => '/tmp/scout_apm_core',
             ConfigKey::CORE_AGENT_DOWNLOAD_ENABLED => true,
             ConfigKey::CORE_AGENT_LAUNCH_ENABLED => true,
-            ConfigKey::CORE_AGENT_VERSION => 'v1.2.7',
+            ConfigKey::CORE_AGENT_VERSION => 'v1.2.8',
             ConfigKey::CORE_AGENT_DOWNLOAD_URL => 'https://s3-us-west-1.amazonaws.com/scout-public-downloads/apm_core_agent/release',
             ConfigKey::CORE_AGENT_PERMISSIONS => 0777,
             ConfigKey::MONITORING_ENABLED => false,


### PR DESCRIPTION
Now that core-agent 1.2.8 is released, this change sets the default version
downloaded to be the latest 1.2.8 release.﻿
