### PR TITLE
Fix missing env in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ jobs:
           - "7.2"
           - "7.3"
           - "7.4"
+    env:
+      SCOUT_APM_KEY: ${{ secrets.SCOUT_APM_KEY }}
     steps:
       - uses: actions/checkout@v2
       - name: "Install PHP"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: "Install PHP"
-        uses: "shivammathur/setup-php@1.8.2"
+        uses: shivammathur/setup-php@v2
         with:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: "Install PHP"
-        uses: "shivammathur/setup-php@1.8.2"
+        uses: shivammathur/setup-php@v2
         with:
           coverage: "none"
           php-version: "7.4"
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: "Install PHP"
-        uses: "shivammathur/setup-php@1.8.2"
+        uses: shivammathur/setup-php@v2
         with:
           coverage: "none"
           php-version: "7.4"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 4.4.0 - 2020-05-27
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- [#178](https://github.com/scoutapp/scout-apm-php/pull/178) Make GitLab Actions work for CI with SCOUT_APM_KEY
+- [#177](https://github.com/scoutapp/scout-apm-php/pull/177) Updated dependencies (and allow ramsey/uuid ^4.0)
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 4.3.0 - 2020-04-01
 
 ### Added

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -31,4 +31,7 @@
             <directory>./src/</directory>
         </whitelist>
     </filter>
+    <listeners>
+        <listener class="Scoutapm\IntegrationTests\CheckScoutApmKeyListener"></listener>
+    </listeners>
 </phpunit>

--- a/tests/Integration/AgentTest.php
+++ b/tests/Integration/AgentTest.php
@@ -47,7 +47,7 @@ final class AgentTest extends TestCase
         // Note, env var name is intentionally inconsistent (i.e. not `SCOUT_KEY`) as we only want to affect this test
         $this->scoutApmKey = getenv('SCOUT_APM_KEY');
 
-        if ($this->scoutApmKey === false) {
+        if ($this->scoutApmKey === false || $this->scoutApmKey === '') {
             self::markTestSkipped('Set the environment variable SCOUT_APM_KEY to enable this test.');
 
             return;

--- a/tests/Integration/CheckScoutApmKeyListener.php
+++ b/tests/Integration/CheckScoutApmKeyListener.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scoutapm\IntegrationTests;
+
+use PHPUnit\Framework\TestListener;
+use PHPUnit\Framework\TestListenerDefaultImplementation;
+use PHPUnit\Framework\TestSuite;
+use function getenv;
+use function sprintf;
+use function str_repeat;
+use function strlen;
+use function substr;
+
+final class CheckScoutApmKeyListener implements TestListener
+{
+    /** @var bool */
+    private $hasOutput = false;
+
+    private const SHOW_CHARACTERS_OF_KEY = 2;
+    use TestListenerDefaultImplementation;
+
+    public function startTestSuite(TestSuite $suite) : void
+    {
+        if ($this->hasOutput) {
+            return;
+        }
+
+        $scoutApmKey = getenv('SCOUT_APM_KEY');
+
+        if ($scoutApmKey === false || $scoutApmKey === '') {
+            echo "Running without SCOUT_APM_KEY configured, some tests will be skipped.\n\n";
+            $this->hasOutput = true;
+
+            return;
+        }
+
+        echo sprintf(
+            "Running with SCOUT_APM_KEY set %s%s\n\n",
+            substr($scoutApmKey, 0, self::SHOW_CHARACTERS_OF_KEY),
+            str_repeat('*', strlen($scoutApmKey) - self::SHOW_CHARACTERS_OF_KEY)
+        );
+        $this->hasOutput = true;
+    }
+}

--- a/tests/isolated-memory-test.php
+++ b/tests/isolated-memory-test.php
@@ -13,7 +13,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $scoutApmKey = getenv('SCOUT_APM_KEY');
 $runCount    = (int) getenv('RUN_COUNT');
 
-if ($scoutApmKey === false || $runCount <= 0) {
+if ($scoutApmKey === false || $scoutApmKey === '' || $runCount <= 0) {
     echo "Try running: \n\n  SCOUT_APM_KEY=abc123 RUN_COUNT=100 php tests/isolated-memory-test.php\n\n";
     throw new RuntimeException('Set the environment variable SCOUT_APM_KEY to enable this test.');
 }


### PR DESCRIPTION
Since some tests use a special environment variable `SCOUT_APM_KEY` (named differently on purpose), we need to import this as a "secret" key (see https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets ).

This needs to be added by @cschneid in the settings before it'll work however...﻿

(relates to #177)
