### PR TITLE
Use a TCP address for core agent communication

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -13,6 +13,7 @@ use Psr\SimpleCache\CacheInterface;
 use Scoutapm\Cache\DevNullCache;
 use Scoutapm\Config\ConfigKey;
 use Scoutapm\Config\IgnoredEndpoints;
+use Scoutapm\Connector\ConnectionAddress;
 use Scoutapm\Connector\Connector;
 use Scoutapm\Connector\Exception\FailedToConnect;
 use Scoutapm\Connector\Exception\FailedToSendCommand;
@@ -109,7 +110,7 @@ final class Agent implements ScoutApmAgent
     private static function createConnectorFromConfig(Config $config) : SocketConnector
     {
         return new SocketConnector(
-            $config->get(ConfigKey::CORE_AGENT_SOCKET_PATH),
+            ConnectionAddress::fromConfig($config),
             $config->get(ConfigKey::MONITORING_ENABLED)
         );
     }
@@ -189,7 +190,7 @@ final class Agent implements ScoutApmAgent
                 ),
                 new Launcher(
                     $this->logger,
-                    $this->config->get(ConfigKey::CORE_AGENT_SOCKET_PATH),
+                    ConnectionAddress::fromConfig($this->config),
                     $this->config->get(ConfigKey::CORE_AGENT_LOG_LEVEL),
                     $this->config->get(ConfigKey::CORE_AGENT_LOG_FILE),
                     $this->config->get(ConfigKey::CORE_AGENT_CONFIG_FILE)

--- a/src/Config/Source/DefaultSource.php
+++ b/src/Config/Source/DefaultSource.php
@@ -50,7 +50,7 @@ final class DefaultSource implements ConfigSource
             ConfigKey::CORE_AGENT_DIRECTORY => '/tmp/scout_apm_core',
             ConfigKey::CORE_AGENT_DOWNLOAD_ENABLED => true,
             ConfigKey::CORE_AGENT_LAUNCH_ENABLED => true,
-            ConfigKey::CORE_AGENT_VERSION => 'v1.2.9',
+            ConfigKey::CORE_AGENT_VERSION => 'v1.3.0',
             ConfigKey::CORE_AGENT_DOWNLOAD_URL => 'https://s3-us-west-1.amazonaws.com/scout-public-downloads/apm_core_agent/release',
             ConfigKey::CORE_AGENT_PERMISSIONS => 0777,
             ConfigKey::MONITORING_ENABLED => false,

--- a/src/Config/Source/DerivedSource.php
+++ b/src/Config/Source/DerivedSource.php
@@ -57,10 +57,7 @@ final class DerivedSource implements ConfigSource
 
     private function socketPath() : string
     {
-        $dir      = $this->config->get(ConfigKey::CORE_AGENT_DIRECTORY);
-        $fullName = $this->config->get(ConfigKey::CORE_AGENT_FULL_NAME);
-
-        return $dir . '/' . $fullName . '/scout-agent.sock';
+        return 'tcp://127.0.0.1:6590';
     }
 
     private function coreAgentFullName() : string

--- a/src/Connector/ConnectionAddress.php
+++ b/src/Connector/ConnectionAddress.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scoutapm\Connector;
+
+use LogicException;
+use Scoutapm\Config;
+use Scoutapm\Config\ConfigKey;
+use function explode;
+use function strlen;
+use function strpos;
+use function substr;
+
+/** @internal */
+final class ConnectionAddress
+{
+    private const TCP_ADDRESS_MARKER = 'tcp://';
+
+    /** @var string */
+    private $path;
+
+    private function __construct(string $path)
+    {
+        $this->path = $path;
+    }
+
+    public static function fromConfig(Config $config) : self
+    {
+        return new self($config->get(ConfigKey::CORE_AGENT_SOCKET_PATH));
+    }
+
+    public function isTcpAddress() : bool
+    {
+        /** @noinspection StrStartsWithCanBeUsedInspection */
+        return strpos($this->path, self::TCP_ADDRESS_MARKER) === 0;
+    }
+
+    public function isSocketPath() : bool
+    {
+        return ! $this->isTcpAddress();
+    }
+
+    public function socketPath() : string
+    {
+        if (! $this->isSocketPath()) {
+            throw new LogicException('Cannot extract socket path from a non-socket address');
+        }
+
+        return $this->path;
+    }
+
+    public function tcpBindAddressPort() : string
+    {
+        if (! $this->isTcpAddress()) {
+            throw new LogicException('Cannot extract TCP address from a non-TCP address');
+        }
+
+        return substr($this->path, strlen(self::TCP_ADDRESS_MARKER));
+    }
+
+    public function tcpBindAddress() : string
+    {
+        return explode(':', $this->tcpBindAddressPort(), 2)[0];
+    }
+
+    public function tcpBindPort() : int
+    {
+        return (int) explode(':', $this->tcpBindAddressPort(), 2)[1];
+    }
+
+    public function toString() : string
+    {
+        return $this->path;
+    }
+}

--- a/src/Connector/Exception/FailedToConnect.php
+++ b/src/Connector/Exception/FailedToConnect.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace Scoutapm\Connector\Exception;
 
 use RuntimeException;
+use Scoutapm\Connector\ConnectionAddress;
 use Throwable;
 use function sprintf;
 
 final class FailedToConnect extends RuntimeException
 {
-    public static function fromSocketPathAndPrevious(string $socketPath, Throwable $previous) : self
+    public static function fromSocketPathAndPrevious(ConnectionAddress $connectionAddress, Throwable $previous) : self
     {
         return new self(sprintf(
-            'Failed to connect to socket on path "%s", previous message: %s',
-            $socketPath,
+            'Failed to connect to socket on address "%s", previous message: %s',
+            $connectionAddress->toString(),
             $previous->getMessage()
         ));
     }

--- a/src/Connector/Exception/FailedToSendCommand.php
+++ b/src/Connector/Exception/FailedToSendCommand.php
@@ -6,6 +6,7 @@ namespace Scoutapm\Connector\Exception;
 
 use RuntimeException;
 use Scoutapm\Connector\Command;
+use Scoutapm\Connector\ConnectionAddress;
 use function get_class;
 use function socket_last_error;
 use function socket_strerror;
@@ -14,67 +15,67 @@ use function sprintf;
 final class FailedToSendCommand extends RuntimeException
 {
     /** @param resource $socketResource */
-    public static function writingMessageSizeToSocket(Command $attemptedCommand, $socketResource, string $socketPath) : self
+    public static function writingMessageSizeToSocket(Command $attemptedCommand, $socketResource, ConnectionAddress $connectionAddress) : self
     {
         $socketErrorNumber = socket_last_error($socketResource);
 
         return new self(sprintf(
-            'Failed to write message size for %s - error %d (%s). Socket path was: %s',
+            'Failed to write message size for %s - error %d (%s). Address was: %s',
             get_class($attemptedCommand),
             $socketErrorNumber,
             socket_strerror($socketErrorNumber),
-            $socketPath
+            $connectionAddress->toString()
         ));
     }
 
     /** @param resource $socketResource */
-    public static function writingMessageContentToSocket(Command $attemptedCommand, $socketResource, string $socketPath) : self
+    public static function writingMessageContentToSocket(Command $attemptedCommand, $socketResource, ConnectionAddress $connectionAddress) : self
     {
         $socketErrorNumber = socket_last_error($socketResource);
 
         return new self(sprintf(
-            'Failed to write message content for %s - error %d (%s). Socket path was: %s',
+            'Failed to write message content for %s - error %d (%s). Address was: %s',
             get_class($attemptedCommand),
             $socketErrorNumber,
             socket_strerror($socketErrorNumber),
-            $socketPath
+            $connectionAddress->toString()
         ));
     }
 
     /** @param resource $socketResource */
-    public static function readingResponseSizeFromSocket(Command $attemptedCommand, $socketResource, string $socketPath) : self
+    public static function readingResponseSizeFromSocket(Command $attemptedCommand, $socketResource, ConnectionAddress $connectionAddress) : self
     {
         $socketErrorNumber = socket_last_error($socketResource);
 
         return new self(sprintf(
-            'Failed to read response size for %s - error %d (%s). Socket path was: %s',
+            'Failed to read response size for %s - error %d (%s). Address was: %s',
             get_class($attemptedCommand),
             $socketErrorNumber,
             socket_strerror($socketErrorNumber),
-            $socketPath
+            $connectionAddress->toString()
         ));
     }
 
-    public static function fromEmptyResponseSize(Command $attemptedCommand, string $socketPath) : self
+    public static function fromEmptyResponseSize(Command $attemptedCommand, ConnectionAddress $connectionAddress) : self
     {
         return new self(sprintf(
-            'Response size was not returned for %s (empty string). Socket path was: %s',
+            'Response size was not returned for %s (empty string). Address was: %s',
             get_class($attemptedCommand),
-            $socketPath
+            $connectionAddress->toString()
         ));
     }
 
     /** @param resource $socketResource */
-    public static function readingResponseContentFromSocket(Command $attemptedCommand, $socketResource, string $socketPath) : self
+    public static function readingResponseContentFromSocket(Command $attemptedCommand, $socketResource, ConnectionAddress $connectionAddress) : self
     {
         $socketErrorNumber = socket_last_error($socketResource);
 
         return new self(sprintf(
-            'Failed to read response content for %s - error %d (%s). Socket path was: %s',
+            'Failed to read response content for %s - error %d (%s). Address was: %s',
             get_class($attemptedCommand),
             $socketErrorNumber,
             socket_strerror($socketErrorNumber),
-            $socketPath
+            $connectionAddress->toString()
         ));
     }
 }

--- a/src/Connector/Exception/NotConnected.php
+++ b/src/Connector/Exception/NotConnected.php
@@ -5,15 +5,16 @@ declare(strict_types=1);
 namespace Scoutapm\Connector\Exception;
 
 use RuntimeException;
+use Scoutapm\Connector\ConnectionAddress;
 use function sprintf;
 
 final class NotConnected extends RuntimeException
 {
-    public static function fromSocketPath(string $socketPath) : self
+    public static function fromSocketPath(ConnectionAddress $connectionAddress) : self
     {
         return new self(sprintf(
-            'Connector has not been connected to socket path "%s"',
-            $socketPath
+            'Connector has not been connected to address "%s"',
+            $connectionAddress->toString()
         ));
     }
 }

--- a/tests/Integration/AgentTest.php
+++ b/tests/Integration/AgentTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\Test\TestLogger;
 use Scoutapm\Agent;
 use Scoutapm\Config;
+use Scoutapm\Config\ConfigKey;
 use Scoutapm\Connector\ConnectionAddress;
 use Scoutapm\Connector\SocketConnector;
 use Scoutapm\Events\Span\Span;
@@ -22,6 +23,7 @@ use function meminfo_dump;
 use function memory_get_usage;
 use function next;
 use function reset;
+use function shell_exec;
 use function sleep;
 use function sprintf;
 use function str_repeat;
@@ -29,6 +31,8 @@ use function str_repeat;
 /** @coversNothing */
 final class AgentTest extends TestCase
 {
+    private const APPLICATION_NAME = 'Agent Integration Test';
+
     /** @var TestLogger */
     private $logger;
     /** @var MessageCapturingConnectorDelegator */
@@ -42,8 +46,6 @@ final class AgentTest extends TestCase
     {
         parent::setUp();
 
-        $this->logger = new TestLogger();
-
         // Note, env var name is intentionally inconsistent (i.e. not `SCOUT_KEY`) as we only want to affect this test
         $this->scoutApmKey = getenv('SCOUT_APM_KEY');
 
@@ -52,12 +54,26 @@ final class AgentTest extends TestCase
 
             return;
         }
+    }
 
-        $config = Config::fromArray([
-            'name' => 'Agent Integration Test',
-            'key' => $this->scoutApmKey,
-            'monitor' => true,
-        ]);
+    public function tearDown() : void
+    {
+        parent::tearDown();
+
+        $this->cleanUpTestAssets();
+    }
+
+    private function cleanUpTestAssets() : void
+    {
+        shell_exec('killall -q core-agent || true');
+        shell_exec('rm -Rf /tmp/scout_apm_core');
+    }
+
+    private function setUpWithConfiguration(Config $config) : void
+    {
+        $config->set(ConfigKey::APPLICATION_KEY, $this->scoutApmKey);
+
+        $this->logger = new TestLogger();
 
         $this->connector = new MessageCapturingConnectorDelegator(
             new SocketConnector(ConnectionAddress::fromConfig($config), true)
@@ -82,8 +98,14 @@ final class AgentTest extends TestCase
         return $return;
     }
 
+    /** @runInSeparateProcess */
     public function testForMemoryLeaksWhenHandlingJobQueues() : void
     {
+        $this->setUpWithConfiguration(Config::fromArray([
+            ConfigKey::APPLICATION_NAME => self::APPLICATION_NAME,
+            ConfigKey::MONITORING_ENABLED => true,
+        ]));
+
         $tagSize = 500000;
 
         $startingMemory = memory_get_usage();
@@ -124,9 +146,40 @@ final class AgentTest extends TestCase
         self::assertLessThan($tagSize * 2, memory_get_usage() - $startingMemory);
     }
 
-    /** @throws Exception */
-    public function testLoggingIsSent() : void
+    /**
+     * @return Config[][]
+     *
+     * @psalm-return array<string,list<Config>>
+     */
+    public function endToEndConfigurationProvider() : array
     {
+        return [
+            'defaultBasicConfiguration' => [
+                Config::fromArray([
+                    ConfigKey::APPLICATION_NAME => self::APPLICATION_NAME,
+                    ConfigKey::MONITORING_ENABLED => true,
+                ]),
+            ],
+            'unixSocketConfiguration' => [
+                Config::fromArray([
+                    ConfigKey::APPLICATION_NAME => self::APPLICATION_NAME,
+                    ConfigKey::MONITORING_ENABLED => true,
+                    ConfigKey::CORE_AGENT_SOCKET_PATH => '/tmp/scout_apm_core/core-agent.sock',
+                ]),
+            ],
+        ];
+    }
+
+    /**
+     * @throws Exception
+     *
+     * @runInSeparateProcess
+     * @dataProvider endToEndConfigurationProvider
+     */
+    public function testLoggingIsSentUsingConfiguration(Config $config) : void
+    {
+        $this->setUpWithConfiguration($config);
+
         $this->agent->webTransaction('Yay', function () : void {
             file_get_contents(__FILE__);
             $this->agent->instrument('Test', 'foo', function () : void {

--- a/tests/Integration/AgentTest.php
+++ b/tests/Integration/AgentTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\Test\TestLogger;
 use Scoutapm\Agent;
 use Scoutapm\Config;
-use Scoutapm\Config\ConfigKey;
+use Scoutapm\Connector\ConnectionAddress;
 use Scoutapm\Connector\SocketConnector;
 use Scoutapm\Events\Span\Span;
 use Scoutapm\Extension\PotentiallyAvailableExtensionCapabilities;
@@ -60,7 +60,7 @@ final class AgentTest extends TestCase
         ]);
 
         $this->connector = new MessageCapturingConnectorDelegator(
-            new SocketConnector($config->get(ConfigKey::CORE_AGENT_SOCKET_PATH), true)
+            new SocketConnector(ConnectionAddress::fromConfig($config), true)
         );
 
         $_SERVER['REQUEST_URI'] = '/fake-path';

--- a/tests/Unit/AgentTest.php
+++ b/tests/Unit/AgentTest.php
@@ -529,7 +529,7 @@ final class AgentTest extends TestCase
         $agent->connect();
 
         self::assertTrue($this->logger->hasWarningThatContains(
-            'Failed to connect to socket on path "/socket/path/should/not/exist"'
+            'Failed to connect to socket on address "/socket/path/should/not/exist"'
         ));
     }
 

--- a/tests/Unit/Config/Source/DerivedSourceTest.php
+++ b/tests/Unit/Config/Source/DerivedSourceTest.php
@@ -50,10 +50,8 @@ final class DerivedSourceTest extends TestCase
 
     public function testSocketPathIsDerivedCorrectly() : void
     {
-        $this->config->set(ConfigKey::CORE_AGENT_FULL_NAME, '__core_agent_full_name__');
-
         self::assertSame(
-            '/tmp/scout_apm_core/__core_agent_full_name__/scout-agent.sock',
+            'tcp://127.0.0.1:6590',
             $this->derivedSource->get(ConfigKey::CORE_AGENT_SOCKET_PATH)
         );
     }

--- a/tests/Unit/Connector/ConnectionAddressTest.php
+++ b/tests/Unit/Connector/ConnectionAddressTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scoutapm\UnitTests\Connector;
+
+use PHPUnit\Framework\TestCase;
+use Scoutapm\Config;
+use Scoutapm\Connector\ConnectionAddress;
+use Throwable;
+
+/** @covers \Scoutapm\Connector\ConnectionAddress */
+final class ConnectionAddressTest extends TestCase
+{
+    private function connectionAddressFromString(string $connectionAddress) : ConnectionAddress
+    {
+        $config = new Config();
+        $config->set(Config\ConfigKey::CORE_AGENT_SOCKET_PATH, $connectionAddress);
+
+        return ConnectionAddress::fromConfig($config);
+    }
+
+    private function expectExceptionInCall(callable $callableThatShouldThrow, string $message) : void
+    {
+        try {
+            $callableThatShouldThrow();
+            self::fail($message);
+        } catch (Throwable $_) {
+            // exception is expected
+        }
+    }
+
+    public function testConnectionAddressWithTcpAddress() : void
+    {
+        $connectionAddress = $this->connectionAddressFromString('tcp://192.168.1.250:1234');
+
+        self::assertSame('tcp://192.168.1.250:1234', $connectionAddress->toString());
+
+        self::assertFalse($connectionAddress->isSocketPath());
+        $this->expectExceptionInCall(
+            static function () use ($connectionAddress) : void {
+                $connectionAddress->socketPath();
+            },
+            'Trying to retrieve a socket path should throw an exception'
+        );
+
+        self::assertTrue($connectionAddress->isTcpAddress());
+
+        self::assertSame('192.168.1.250:1234', $connectionAddress->tcpBindAddressPort());
+        self::assertSame('192.168.1.250', $connectionAddress->tcpBindAddress());
+        self::assertSame(1234, $connectionAddress->tcpBindPort());
+    }
+
+    public function testConnectionAddressWithSocketPath() : void
+    {
+        $connectionAddress = $this->connectionAddressFromString('/path/to/my/socket');
+
+        self::assertSame('/path/to/my/socket', $connectionAddress->toString());
+
+        self::assertTrue($connectionAddress->isSocketPath());
+        self::assertSame('/path/to/my/socket', $connectionAddress->socketPath());
+
+        self::assertFalse($connectionAddress->isTcpAddress());
+        $this->expectExceptionInCall(
+            static function () use ($connectionAddress) : void {
+                $connectionAddress->tcpBindAddressPort();
+            },
+            'Trying to retrieve a TCP address/port should throw an exception'
+        );
+        $this->expectExceptionInCall(
+            static function () use ($connectionAddress) : void {
+                $connectionAddress->tcpBindAddress();
+            },
+            'Trying to retrieve a TCP address should throw an exception'
+        );
+        $this->expectExceptionInCall(
+            static function () use ($connectionAddress) : void {
+                $connectionAddress->tcpBindPort();
+            },
+            'Trying to retrieve a TCP port should throw an exception'
+        );
+    }
+}

--- a/tests/Unit/Connector/ConnectionAddressTest.php
+++ b/tests/Unit/Connector/ConnectionAddressTest.php
@@ -30,11 +30,81 @@ final class ConnectionAddressTest extends TestCase
         }
     }
 
-    public function testConnectionAddressWithTcpAddress() : void
+    /**
+     * @return string[][]|int[][]
+     *
+     * @psalm-return list<array{configuration:string,address:string,port:int,both:string}>
+     */
+    public function tcpAddressProvider() : array
     {
-        $connectionAddress = $this->connectionAddressFromString('tcp://192.168.1.250:1234');
+        return [
+            [
+                'configuration' => 'tcp://192.168.1.250:1234',
+                'address' => '192.168.1.250',
+                'port' => 1234,
+                'both' => '192.168.1.250:1234',
+            ],
+            [
+                'configuration' => 'tcp://my-hostname:1234',
+                'address' => 'my-hostname',
+                'port' => 1234,
+                'both' => 'my-hostname:1234',
+            ],
+            [
+                'configuration' => 'tcp://192.168.1.250',
+                'address' => '192.168.1.250',
+                'port' => 6590,
+                'both' => '192.168.1.250:6590',
+            ],
+            [
+                'configuration' => 'tcp://my-hostname',
+                'address' => 'my-hostname',
+                'port' => 6590,
+                'both' => 'my-hostname:6590',
+            ],
+            [
+                'configuration' => 'tcp://192.168.1.250:',
+                'address' => '192.168.1.250',
+                'port' => 6590,
+                'both' => '192.168.1.250:6590',
+            ],
+            [
+                'configuration' => 'tcp://my-hostname:',
+                'address' => 'my-hostname',
+                'port' => 6590,
+                'both' => 'my-hostname:6590',
+            ],
+            [
+                'configuration' => 'tcp://:1234',
+                'address' => '127.0.0.1',
+                'port' => 1234,
+                'both' => '127.0.0.1:1234',
+            ],
+            [
+                'configuration' => 'tcp://:',
+                'address' => '127.0.0.1',
+                'port' => 6590,
+                'both' => '127.0.0.1:6590',
+            ],
+            [
+                'configuration' => 'tcp://',
+                'address' => '127.0.0.1',
+                'port' => 6590,
+                'both' => '127.0.0.1:6590',
+            ],
+        ];
+    }
 
-        self::assertSame('tcp://192.168.1.250:1234', $connectionAddress->toString());
+    /** @dataProvider tcpAddressProvider */
+    public function testConnectionAddressWithTcpAddress(
+        string $configuration,
+        string $address,
+        int $port,
+        string $both
+    ) : void {
+        $connectionAddress = $this->connectionAddressFromString($configuration);
+
+        self::assertSame($configuration, $connectionAddress->toString());
 
         self::assertFalse($connectionAddress->isSocketPath());
         $this->expectExceptionInCall(
@@ -46,9 +116,9 @@ final class ConnectionAddressTest extends TestCase
 
         self::assertTrue($connectionAddress->isTcpAddress());
 
-        self::assertSame('192.168.1.250:1234', $connectionAddress->tcpBindAddressPort());
-        self::assertSame('192.168.1.250', $connectionAddress->tcpBindAddress());
-        self::assertSame(1234, $connectionAddress->tcpBindPort());
+        self::assertSame($address, $connectionAddress->tcpBindAddress());
+        self::assertSame($port, $connectionAddress->tcpBindPort());
+        self::assertSame($both, $connectionAddress->tcpBindAddressPort());
     }
 
     public function testConnectionAddressWithSocketPath() : void

--- a/tests/Unit/Connector/SocketConnectorTest.php
+++ b/tests/Unit/Connector/SocketConnectorTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Scoutapm\UnitTests\Connector;
 
 use PHPUnit\Framework\TestCase;
+use Scoutapm\Config;
+use Scoutapm\Connector\ConnectionAddress;
 use Scoutapm\Connector\Exception\FailedToConnect;
 use Scoutapm\Connector\SocketConnector;
 
@@ -13,7 +15,10 @@ final class SocketConnectorTest extends TestCase
 {
     public function testExceptionIsRaisedWhenConnectingToNonExistentSocket() : void
     {
-        $connector = new SocketConnector('/path/does/not/exist', false);
+        $config = new Config();
+        $config->set(Config\ConfigKey::CORE_AGENT_SOCKET_PATH, '/path/does/not/exist');
+
+        $connector = new SocketConnector(ConnectionAddress::fromConfig($config), false);
 
         $this->expectException(FailedToConnect::class);
         $this->expectExceptionMessage('socket_connect(): unable to connect [2]: No such file or directory');

--- a/tests/Unit/CoreAgent/LauncherTest.php
+++ b/tests/Unit/CoreAgent/LauncherTest.php
@@ -6,18 +6,28 @@ namespace Scoutapm\UnitTests\CoreAgent;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\Test\TestLogger;
+use Scoutapm\Config;
+use Scoutapm\Connector\ConnectionAddress;
 use Scoutapm\CoreAgent\Launcher;
 
 /** @covers \Scoutapm\CoreAgent\Launcher */
 final class LauncherTest extends TestCase
 {
+    private function connectionAddressFromString(string $connectionAddress) : ConnectionAddress
+    {
+        $config = new Config();
+        $config->set(Config\ConfigKey::CORE_AGENT_SOCKET_PATH, $connectionAddress);
+
+        return ConnectionAddress::fromConfig($config);
+    }
+
     public function testLaunchingCoreAgentWithInvalidGlibcIsCaught() : void
     {
         $logger = new TestLogger();
 
         $launcher = new Launcher(
             $logger,
-            'socket-path.sock',
+            $this->connectionAddressFromString('socket-path.sock'),
             null,
             null,
             null
@@ -33,7 +43,7 @@ final class LauncherTest extends TestCase
 
         $launcher = new Launcher(
             $logger,
-            'socket-path.sock',
+            $this->connectionAddressFromString('socket-path.sock'),
             null,
             null,
             null
@@ -49,7 +59,7 @@ final class LauncherTest extends TestCase
 
         $launcher = new Launcher(
             $logger,
-            '/tmp/socket-path.sock',
+            $this->connectionAddressFromString('/tmp/socket-path.sock'),
             'TRACE',
             '/tmp/core-agent.log',
             '/tmp/core-agent-config.ini'

--- a/tests/check-memory-leaks.sh
+++ b/tests/check-memory-leaks.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 
 cd "$(dirname "$0")"
 
+# Run it once first to allow the agent to be downloaded & executed to avoid skewing results
+killall -q core-agent || true
+rm -Rf /tmp/scout*
+RUN_COUNT=1 php isolated-memory-test.php > /dev/null
+
 SINGLE=$(RUN_COUNT=1 php isolated-memory-test.php)
 echo "Single execution used: $SINGLE bytes"
 


### PR DESCRIPTION
Fixes #184

- Added ConnectionAddress value object for TCP/socket path support
- Use ConnectionAddress to determine whether to use TCP or UNIX sockets
- Set default core_agent_socket_path configuration to TCP address 127.0.0.1:6590
