### PR TITLE
Adds Lumen support

### DIFF
--- a/.github/fixtures/lumen-app.php
+++ b/.github/fixtures/lumen-app.php
@@ -1,0 +1,119 @@
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+(new Laravel\Lumen\Bootstrap\LoadEnvironmentVariables(
+    dirname(__DIR__)
+))->bootstrap();
+
+date_default_timezone_set(env('APP_TIMEZONE', 'UTC'));
+
+/*
+|--------------------------------------------------------------------------
+| Create The Application
+|--------------------------------------------------------------------------
+|
+| Here we will load the environment and create the application instance
+| that serves as the central piece of this framework. We'll use this
+| application as an "IoC" container and router for this framework.
+|
+*/
+
+$app = new Laravel\Lumen\Application(
+    dirname(__DIR__)
+);
+
+ $app->withFacades();
+
+// $app->withEloquent();
+
+/*
+|--------------------------------------------------------------------------
+| Register Container Bindings
+|--------------------------------------------------------------------------
+|
+| Now we will register a few bindings in the service container. We will
+| register the exception handler and the console kernel. You may add
+| your own bindings here if you like or you can make another file.
+|
+*/
+
+$app->singleton(
+    Illuminate\Contracts\Debug\ExceptionHandler::class,
+    App\Exceptions\Handler::class
+);
+
+$app->singleton(
+    Illuminate\Contracts\Console\Kernel::class,
+    App\Console\Kernel::class
+);
+
+/*
+|--------------------------------------------------------------------------
+| Register Config Files
+|--------------------------------------------------------------------------
+|
+| Now we will register the "app" configuration file. If the file exists in
+| your configuration directory it will be loaded; otherwise, we'll load
+| the default version. You may register other files below as needed.
+|
+*/
+
+$app->configure('app');
+
+/*
+|--------------------------------------------------------------------------
+| Register Middleware
+|--------------------------------------------------------------------------
+|
+| Next, we will register the middleware with the application. These can
+| be global middleware that run before and after each request into a
+| route or middleware that'll be assigned to some specific routes.
+|
+*/
+
+ $app->middleware([
+     \Scoutapm\Laravel\Middleware\SendRequestToScout::class,
+     \Scoutapm\Laravel\Middleware\IgnoredEndpoints::class,
+     \Scoutapm\Laravel\Middleware\MiddlewareInstrument::class,
+     \Scoutapm\Laravel\Middleware\ActionInstrument::class,
+ ]);
+
+// $app->routeMiddleware([
+//     'auth' => App\Http\Middleware\Authenticate::class,
+// ]);
+
+/*
+|--------------------------------------------------------------------------
+| Register Service Providers
+|--------------------------------------------------------------------------
+|
+| Here we will register all of the application's service providers which
+| are used to bind services into the container. Service providers are
+| totally optional, so you are not required to uncomment this line.
+|
+*/
+
+// $app->register(App\Providers\AppServiceProvider::class);
+// $app->register(App\Providers\AuthServiceProvider::class);
+$app->register(App\Providers\EventServiceProvider::class);
+$app->register(\Scoutapm\Laravel\Providers\ScoutApmServiceProvider::class);
+
+/*
+|--------------------------------------------------------------------------
+| Load The Application Routes
+|--------------------------------------------------------------------------
+|
+| Next we will include the routes file so that they can all be added to
+| the application. This will provide all of the URLs the application
+| can respond to, as well as the controllers that may handle them.
+|
+*/
+
+$app->router->group([
+    'namespace' => 'App\Http\Controllers',
+], function ($router) {
+    require __DIR__.'/../routes/web.php';
+});
+
+return $app;

--- a/.github/fixtures/lumen-app.php
+++ b/.github/fixtures/lumen-app.php
@@ -2,9 +2,18 @@
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-(new Laravel\Lumen\Bootstrap\LoadEnvironmentVariables(
-    dirname(__DIR__)
-))->bootstrap();
+// LoadEnvironmentVariables since Lumen 6.*
+if (class_exists(Laravel\Lumen\Bootstrap\LoadEnvironmentVariables::class)) {
+    (new Laravel\Lumen\Bootstrap\LoadEnvironmentVariables(
+        dirname(__DIR__)
+    ))->bootstrap();
+} else {
+    try {
+        (new Dotenv\Dotenv(__DIR__.'/../'))->load();
+    } catch (Dotenv\Exception\InvalidPathException $e) {
+        //
+    }
+}
 
 date_default_timezone_set(env('APP_TIMEZONE', 'UTC'));
 

--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -71,6 +71,7 @@ jobs:
           - {php-version: "7.1", laravel-version: "7.*"} # Laravel 7 requires 7.2+
           - {php-version: "7.1", laravel-version: "8.*"} # Laravel 8 requires 7.3+
           - {php-version: "7.2", laravel-version: "8.*"} # Laravel 8 requires 7.3+
+          - {php-version: "8.0", laravel-version: "5.5.*"} # Laravel 5.5.* does not support PHP 8.0+
     env:
       SCOUT_APM_KEY: ${{ secrets.SCOUT_APM_KEY }}
     steps:

--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -65,6 +65,7 @@ jobs:
           - "7.2"
           - "7.3"
           - "7.4"
+          - "8.0"
         exclude:
           - {php-version: "7.1", laravel-version: "6.*"} # Laravel 6 requires 7.2+
           - {php-version: "7.1", laravel-version: "7.*"} # Laravel 7 requires 7.2+

--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -40,8 +40,8 @@ jobs:
           extensions: ${{ matrix.extensions }}
       # --no-update then a full `composer update` is needed to overcome locked dependencies
       # See: https://github.com/composer/composer/issues/9561
-      - name: "Remove symfony components (conflicts)"
-        run: "composer remove --dev symfony/* --no-update --no-interaction"
+      - name: "Remove existing requirements components (avoid conflicts)"
+        run: "composer remove --dev symfony/* laravel/* --no-update --no-interaction"
       - name: "Require framework ${{ matrix.laravel-version}}"
         run: "composer require laravel/framework:${{ matrix.laravel-version}} --no-update --no-interaction --prefer-dist --prefer-stable"
       - name: "Composer update with new requirements"

--- a/.github/workflows/lumen.yml
+++ b/.github/workflows/lumen.yml
@@ -94,7 +94,7 @@ jobs:
       - name: "Require scout-apm-php current checkout"
         run: cd test-app && composer require scoutapp/scout-apm-php:*@dev composer/package-versions-deprecated
       - name: "Configure the application"
-        run: cd test-app && cp ../scout-apm-php/.github/fixtures/lumen-app.php bootstrap/app.php"
+        run: cd test-app && cp ../scout-apm-php/.github/fixtures/lumen-app.php bootstrap/app.php
       - name: "Configure Scout"
         run: cd test-app && echo -e "\nSCOUT_KEY=\"\${SCOUT_APM_KEY}\"\nSCOUT_NAME=\"My Lumen App\"\nSCOUT_MONITOR=true" >> .env
       - name: "Load the index page to trigger instrumentation"

--- a/.github/workflows/lumen.yml
+++ b/.github/workflows/lumen.yml
@@ -1,0 +1,109 @@
+name: Lumen Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  lumen-unit-tests:
+    name: "Lumen Tests"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        extensions: ["scoutapm", ""]
+        lumen-version:
+          - "5.5.*"
+          - "6.*"
+          - "7.*"
+          - "8.*"
+        php-version:
+          - "7.1"
+          - "7.2"
+          - "7.3"
+          - "7.4"
+          - "8.0"
+        exclude:
+          - {php-version: "7.1", lumen-version: "6.*"} # Lumen 6 requires 7.2+
+          - {php-version: "7.1", lumen-version: "7.*"} # Lumen 7 requires 7.2+
+          - {php-version: "7.1", lumen-version: "8.*"} # Lumen 8 requires 7.3+
+          - {php-version: "7.2", lumen-version: "8.*"} # Lumen 8 requires 7.3+
+    steps:
+      - uses: actions/checkout@v2
+      - name: "Install PHP"
+        uses: shivammathur/setup-php@v2
+        with:
+          coverage: "none"
+          php-version: "${{ matrix.php-version }}"
+          tools: pecl
+          extensions: ${{ matrix.extensions }}
+      # --no-update then a full `composer update` is needed to overcome locked dependencies
+      # See: https://github.com/composer/composer/issues/9561
+      - name: "Remove symfony components (conflicts)"
+        run: "composer remove --dev symfony/* --no-update --no-interaction"
+      - name: "Require framework ${{ matrix.lumen-version}}"
+        run: "composer require laravel/lumen:${{ matrix.lumen-version}} --no-update --no-interaction --prefer-dist --prefer-stable"
+      - name: "Composer update with new requirements"
+        run: "composer update --no-interaction --prefer-dist --prefer-stable"
+      - name: "Run PHPUnit (Lumen) test suite"
+        run: "vendor/bin/phpunit --testsuite=laravel" # Test suite is same as Laravel
+
+  lumen-e2e:
+    name: "Lumen End-to-End Test"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        extensions: ["scoutapm", ""]
+        lumen-version:
+          - "5.5.*"
+          - "6.*"
+          - "7.*"
+          - "8.*"
+        php-version:
+          - "7.1"
+          - "7.2"
+          - "7.3"
+          - "7.4"
+          - "8.0"
+        exclude:
+          - {php-version: "7.1", lumen-version: "6.*"} # Lumen 6 requires 7.2+
+          - {php-version: "7.1", lumen-version: "7.*"} # Lumen 7 requires 7.2+
+          - {php-version: "7.1", lumen-version: "8.*"} # Lumen 8 requires 7.3+
+          - {php-version: "7.2", lumen-version: "8.*"} # Lumen 8 requires 7.3+
+    env:
+      SCOUT_APM_KEY: ${{ secrets.SCOUT_APM_KEY }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: scout-apm-php
+      - name: "Install PHP"
+        uses: shivammathur/setup-php@v2
+        with:
+          coverage: "none"
+          php-version: "${{ matrix.php-version }}"
+          tools: pecl
+          extensions: ${{ matrix.extensions }}
+      - name: "Install Lumen quickstart project"
+        run: "composer create-project laravel/lumen:${{ matrix.lumen-version}} test-app --prefer-dist"
+      - name: "Add scout-apm-php as a repository"
+        run: cd test-app && composer config repositories.scout path ../scout-apm-php
+      - name: "Require scout-apm-php current checkout"
+        run: cd test-app && composer require scoutapp/scout-apm-php:*@dev composer/package-versions-deprecated
+      - name: "Configure the application"
+        run: cd test-app && cp ../scout-apm-php/.github/fixtures/lumen-app.php bootstrap/app.php"
+      - name: "Configure Scout"
+        run: cd test-app && echo -e "\nSCOUT_KEY=\"\${SCOUT_APM_KEY}\"\nSCOUT_NAME=\"My Lumen App\"\nSCOUT_MONITOR=true" >> .env
+      - name: "Load the index page to trigger instrumentation"
+        run: |
+          cd test-app
+          cat .env
+          php -S localhost:8000 -t public/ &
+          sleep 2
+          wget http://localhost:8000
+      - name: "Check logs for successful payload send"
+        run: |
+          cd test-app
+          ls -l storage/logs/
+          cat storage/logs/lumen.log
+          grep -q "local.DEBUG: \[Scout\] Sent whole payload successfully to core agent." storage/logs/lumen.log

--- a/.github/workflows/lumen.yml
+++ b/.github/workflows/lumen.yml
@@ -40,8 +40,8 @@ jobs:
           extensions: ${{ matrix.extensions }}
       # --no-update then a full `composer update` is needed to overcome locked dependencies
       # See: https://github.com/composer/composer/issues/9561
-      - name: "Remove symfony components (conflicts)"
-        run: "composer remove --dev symfony/* --no-update --no-interaction"
+      - name: "Remove existing requirements components (avoid conflicts)"
+        run: "composer remove --dev symfony/* laravel/* --no-update --no-interaction"
       - name: "Require framework ${{ matrix.lumen-version}}"
         run: "composer require laravel/lumen:${{ matrix.lumen-version}} --no-update --no-interaction --prefer-dist --prefer-stable"
       - name: "Composer update with new requirements"

--- a/.github/workflows/lumen.yml
+++ b/.github/workflows/lumen.yml
@@ -91,7 +91,7 @@ jobs:
           tools: pecl
           extensions: ${{ matrix.extensions }}
       - name: "Install Lumen quickstart project"
-        run: "composer create-project laravel/lumen-framework:${{ matrix.lumen-version}} test-app --prefer-dist"
+        run: "composer create-project laravel/lumen:${{ matrix.lumen-version}} test-app --prefer-dist"
       - name: "Add scout-apm-php as a repository"
         run: cd test-app && composer config repositories.scout path ../scout-apm-php
       - name: "Require scout-apm-php current checkout"

--- a/.github/workflows/lumen.yml
+++ b/.github/workflows/lumen.yml
@@ -29,6 +29,7 @@ jobs:
           - {php-version: "7.1", lumen-version: "7.*"} # Lumen 7 requires 7.2+
           - {php-version: "7.1", lumen-version: "8.*"} # Lumen 8 requires 7.3+
           - {php-version: "7.2", lumen-version: "8.*"} # Lumen 8 requires 7.3+
+          - {php-version: "7.4", lumen-version: "5.5.*"} # Lumen 5.5.* does not support PHP 7.4+
           - {php-version: "8.0", lumen-version: "5.5.*"} # Lumen 5.5.* does not support PHP 8.0+
           - {php-version: "8.0", lumen-version: "6.*"} # Lumen 6.* does not support PHP 8.0+
           - {php-version: "8.0", lumen-version: "7.*"} # Lumen 7.* does not support PHP 8.0+

--- a/.github/workflows/lumen.yml
+++ b/.github/workflows/lumen.yml
@@ -71,6 +71,9 @@ jobs:
           - {php-version: "7.1", lumen-version: "7.*"} # Lumen 7 requires 7.2+
           - {php-version: "7.1", lumen-version: "8.*"} # Lumen 8 requires 7.3+
           - {php-version: "7.2", lumen-version: "8.*"} # Lumen 8 requires 7.3+
+          - {php-version: "8.0", lumen-version: "5.5.*"} # Lumen 5.5.* does not support PHP 8.0+
+          - {php-version: "8.0", lumen-version: "6.*"} # Lumen 6.* does not support PHP 8.0+
+          - {php-version: "8.0", lumen-version: "7.*"} # Lumen 7.* does not support PHP 8.0+
     env:
       SCOUT_APM_KEY: ${{ secrets.SCOUT_APM_KEY }}
     steps:
@@ -85,7 +88,7 @@ jobs:
           tools: pecl
           extensions: ${{ matrix.extensions }}
       - name: "Install Lumen quickstart project"
-        run: "composer create-project laravel/lumen:${{ matrix.lumen-version}} test-app --prefer-dist"
+        run: "composer create-project laravel/lumen-framework:${{ matrix.lumen-version}} test-app --prefer-dist"
       - name: "Add scout-apm-php as a repository"
         run: cd test-app && composer config repositories.scout path ../scout-apm-php
       - name: "Require scout-apm-php current checkout"

--- a/.github/workflows/lumen.yml
+++ b/.github/workflows/lumen.yml
@@ -112,4 +112,4 @@ jobs:
           cd test-app
           ls -l storage/logs/
           cat storage/logs/lumen.log
-          grep -q "local.DEBUG: \[Scout\] Sent whole payload successfully to core agent." storage/logs/lumen.log
+          grep -q "DEBUG: \[Scout\] Sent whole payload successfully to core agent." storage/logs/lumen.log

--- a/.github/workflows/lumen.yml
+++ b/.github/workflows/lumen.yml
@@ -29,6 +29,9 @@ jobs:
           - {php-version: "7.1", lumen-version: "7.*"} # Lumen 7 requires 7.2+
           - {php-version: "7.1", lumen-version: "8.*"} # Lumen 8 requires 7.3+
           - {php-version: "7.2", lumen-version: "8.*"} # Lumen 8 requires 7.3+
+          - {php-version: "8.0", lumen-version: "5.5.*"} # Lumen 5.5.* does not support PHP 8.0+
+          - {php-version: "8.0", lumen-version: "6.*"} # Lumen 6.* does not support PHP 8.0+
+          - {php-version: "8.0", lumen-version: "7.*"} # Lumen 7.* does not support PHP 8.0+
     steps:
       - uses: actions/checkout@v2
       - name: "Install PHP"

--- a/.github/workflows/lumen.yml
+++ b/.github/workflows/lumen.yml
@@ -104,7 +104,7 @@ jobs:
         run: |
           cd test-app
           cat .env
-          php -S localhost:8000 -t public/ &
+          LOG_CHANNEL=single php -S localhost:8000 -t public/ &
           sleep 2
           wget http://localhost:8000
       - name: "Check logs for successful payload send"

--- a/.github/workflows/symfony.yml
+++ b/.github/workflows/symfony.yml
@@ -43,7 +43,7 @@ jobs:
       - name: "Remove existing requirements components (avoid conflicts)"
         run: "composer remove --dev symfony/* laravel/* --no-update --no-interaction"
       - name: "Require Symfony ${{ matrix.symfony-version }}, Twig ${{ matrix.twig-version }}"
-        run: "composer require symfony/symfony:${{ matrix.symfony-version }} twig/twig:${{ matrix.twig-version }} --no-update --no-interaction --prefer-dist --prefer-stable"
+        run: "composer require symfony/symfony:${{ matrix.symfony-version }} twig/twig:${{ matrix.twig-version }} symfony/orm-pack:^2.0 symfony/twig-pack:^1.0 --no-update --no-interaction --prefer-dist --prefer-stable"
       - name: "Composer update with new requirements"
         run: "composer update --no-interaction --prefer-dist --prefer-stable"
       - name: "Run PHPUnit test suite"

--- a/.github/workflows/symfony.yml
+++ b/.github/workflows/symfony.yml
@@ -40,6 +40,8 @@ jobs:
           extensions: ${{ matrix.extensions }}
       # --no-update then a full `composer update` is needed to overcome locked dependencies
       # See: https://github.com/composer/composer/issues/9561
+      - name: "Remove existing requirements components (avoid conflicts)"
+        run: "composer remove --dev symfony/* laravel/* --no-update --no-interaction"
       - name: "Require Symfony ${{ matrix.symfony-version }}, Twig ${{ matrix.twig-version }}"
         run: "composer require symfony/symfony:${{ matrix.symfony-version }} twig/twig:${{ matrix.twig-version }} --no-update --no-interaction --prefer-dist --prefer-stable"
       - name: "Composer update with new requirements"

--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -18,4 +18,11 @@ namespace PHPSTORM_META {
         'events' => \Illuminate\Contracts\Events\Dispatcher::class,
         'db' => \Illuminate\Database\DatabaseManager::class,
     ]));
+    override(\Laravel\Lumen\Application::make(0), map([
+        '' => '@',
+        'log' => \Psr\Log\LoggerInterface::class,
+        'view' => \Illuminate\View\Factory::class,
+        'events' => \Illuminate\Contracts\Events\Dispatcher::class,
+        'db' => \Illuminate\Database\DatabaseManager::class,
+    ]));
 }

--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -1,5 +1,12 @@
 <?php
 namespace PHPSTORM_META {
+    override(\Illuminate\Contracts\Container\Container::make(0), map([
+        '' => '@',
+        'log' => \Psr\Log\LoggerInterface::class,
+        'view' => \Illuminate\View\Factory::class,
+        'events' => \Illuminate\Contracts\Events\Dispatcher::class,
+        'connection' => \Illuminate\Database\Connection::class,
+    ]));
     override(\Illuminate\Foundation\Application::make(0), map([
         '' => '@',
         'view' => \Illuminate\View\Factory::class,
@@ -9,5 +16,6 @@ namespace PHPSTORM_META {
         'log' => \Psr\Log\LoggerInterface::class,
         'view' => \Illuminate\View\Factory::class,
         'events' => \Illuminate\Contracts\Events\Dispatcher::class,
+        'connection' => \Illuminate\Database\Connection::class,
     ]));
 }

--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -6,6 +6,7 @@ namespace PHPSTORM_META {
         'view' => \Illuminate\View\Factory::class,
         'events' => \Illuminate\Contracts\Events\Dispatcher::class,
         'db' => \Illuminate\Database\DatabaseManager::class,
+        'view.engine.resolver' => \Illuminate\View\Engines\EngineResolver::class,
     ]));
     override(\Illuminate\Foundation\Application::make(0), map([
         '' => '@',
@@ -17,6 +18,7 @@ namespace PHPSTORM_META {
         'view' => \Illuminate\View\Factory::class,
         'events' => \Illuminate\Contracts\Events\Dispatcher::class,
         'db' => \Illuminate\Database\DatabaseManager::class,
+        'view.engine.resolver' => \Illuminate\View\Engines\EngineResolver::class,
     ]));
     override(\Laravel\Lumen\Application::make(0), map([
         '' => '@',
@@ -24,5 +26,6 @@ namespace PHPSTORM_META {
         'view' => \Illuminate\View\Factory::class,
         'events' => \Illuminate\Contracts\Events\Dispatcher::class,
         'db' => \Illuminate\Database\DatabaseManager::class,
+        'view.engine.resolver' => \Illuminate\View\Engines\EngineResolver::class,
     ]));
 }

--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -5,7 +5,7 @@ namespace PHPSTORM_META {
         'log' => \Psr\Log\LoggerInterface::class,
         'view' => \Illuminate\View\Factory::class,
         'events' => \Illuminate\Contracts\Events\Dispatcher::class,
-        'connection' => \Illuminate\Database\Connection::class,
+        'db' => \Illuminate\Database\DatabaseManager::class,
     ]));
     override(\Illuminate\Foundation\Application::make(0), map([
         '' => '@',
@@ -16,6 +16,6 @@ namespace PHPSTORM_META {
         'log' => \Psr\Log\LoggerInterface::class,
         'view' => \Illuminate\View\Factory::class,
         'events' => \Illuminate\Contracts\Events\Dispatcher::class,
-        'connection' => \Illuminate\Database\Connection::class,
+        'db' => \Illuminate\Database\DatabaseManager::class,
     ]));
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 6.1.0 - TBD
+
+### Added
+
+- [#210](https://github.com/scoutapp/scout-apm-php/pull/210) Add support for Lumen 6+
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 6.0.1 - 2021-03-19
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "composer-plugin-api": "^2.0",
         "doctrine/coding-standard": "^8.2",
         "laravel/framework": "^5.5.0|^6.0|^7.0|^8.0",
-        "laravel/lumen-framework": "^8.2",
+        "laravel/lumen-framework": "^5.5.0|^6.0|^7.0|^8.0",
         "monolog/monolog": "^1.26|^2.2.0",
         "phpunit/phpunit": "^7.5.20|^8.5.14|^9.5.2",
         "psalm/plugin-phpunit": "^0.15.1",

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "composer-plugin-api": "^2.0",
         "doctrine/coding-standard": "^8.2",
         "laravel/framework": "^5.5.0|^6.0|^7.0|^8.0",
+        "laravel/lumen-framework": "^8.2",
         "monolog/monolog": "^1.26|^2.2.0",
         "phpunit/phpunit": "^7.5.20|^8.5.14|^9.5.2",
         "psalm/plugin-phpunit": "^0.15.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "12f548beac0f981a324ed7fc3e113f6b",
+    "content-hash": "507aa20931e10cd22f7fb0b9572ddab8",
     "packages": [
         {
             "name": "brick/math",
@@ -3114,6 +3114,103 @@
             "time": "2021-02-16T18:07:44+00:00"
         },
         {
+            "name": "laravel/lumen-framework",
+            "version": "v8.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/lumen-framework.git",
+                "reference": "6ed02d4d1a6e203b9e896bd105b2e838866f2951"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/lumen-framework/zipball/6ed02d4d1a6e203b9e896bd105b2e838866f2951",
+                "reference": "6ed02d4d1a6e203b9e896bd105b2e838866f2951",
+                "shasum": ""
+            },
+            "require": {
+                "dragonmantank/cron-expression": "^3.0.2",
+                "illuminate/auth": "^8.0",
+                "illuminate/broadcasting": "^8.0",
+                "illuminate/bus": "^8.0",
+                "illuminate/cache": "^8.0",
+                "illuminate/collections": "^8.0",
+                "illuminate/config": "^8.0",
+                "illuminate/console": "^8.0",
+                "illuminate/container": "^8.0",
+                "illuminate/contracts": "^8.0",
+                "illuminate/database": "^8.0",
+                "illuminate/encryption": "^8.0",
+                "illuminate/events": "^8.0",
+                "illuminate/filesystem": "^8.0",
+                "illuminate/hashing": "^8.0",
+                "illuminate/http": "^8.0",
+                "illuminate/log": "^8.0",
+                "illuminate/macroable": "^8.0",
+                "illuminate/pagination": "^8.0",
+                "illuminate/pipeline": "^8.0",
+                "illuminate/queue": "^8.0",
+                "illuminate/support": "^8.0",
+                "illuminate/testing": "^8.0",
+                "illuminate/translation": "^8.0",
+                "illuminate/validation": "^8.0",
+                "illuminate/view": "^8.0",
+                "nikic/fast-route": "^1.3",
+                "php": "^7.3|^8.0",
+                "symfony/console": "^5.1",
+                "symfony/error-handler": "^5.1",
+                "symfony/http-foundation": "^5.1",
+                "symfony/http-kernel": "^5.1",
+                "symfony/mime": "^5.1",
+                "symfony/var-dumper": "^5.1",
+                "vlucas/phpdotenv": "^5.2"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.4.2",
+                "phpunit/phpunit": "^8.5.8|^9.3.3"
+            },
+            "suggest": {
+                "laravel/tinker": "Required to use the tinker console command (^2.0).",
+                "nyholm/psr7": "Required to use PSR-7 bridging features (^1.2).",
+                "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^2.0)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Lumen\\": "src/"
+                },
+                "files": [
+                    "src/helpers.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylorotwell@gmail.com"
+                }
+            ],
+            "description": "The Laravel Lumen Framework.",
+            "homepage": "https://lumen.laravel.com",
+            "keywords": [
+                "framework",
+                "laravel",
+                "lumen"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/lumen-framework/issues",
+                "source": "https://github.com/laravel/lumen-framework"
+            },
+            "time": "2021-02-09T16:42:36+00:00"
+        },
+        {
             "name": "league/commonmark",
             "version": "1.5.7",
             "source": {
@@ -3662,6 +3759,56 @@
                 "source": "https://github.com/cweiske/jsonmapper/tree/master"
             },
             "time": "2020-04-16T18:48:43+00:00"
+        },
+        {
+            "name": "nikic/fast-route",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/FastRoute.git",
+                "reference": "181d480e08d9476e61381e04a71b34dc0432e812"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/FastRoute/zipball/181d480e08d9476e61381e04a71b34dc0432e812",
+                "reference": "181d480e08d9476e61381e04a71b34dc0432e812",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35|~5.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "FastRoute\\": "src/"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov",
+                    "email": "nikic@php.net"
+                }
+            ],
+            "description": "Fast request router for PHP",
+            "keywords": [
+                "router",
+                "routing"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/FastRoute/issues",
+                "source": "https://github.com/nikic/FastRoute/tree/master"
+            },
+            "time": "2018-02-13T20:26:39+00:00"
         },
         {
             "name": "nikic/php-parser",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "507aa20931e10cd22f7fb0b9572ddab8",
+    "content-hash": "82f25140eefdbda86038d40d2df8dd7f",
     "packages": [
         {
             "name": "brick/math",
@@ -457,30 +457,35 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.9.1",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0 || ^8.0",
+                "php": "^7.2 || ^8.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
                 "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<3.9.1"
+                "vimeo/psalm": "<4.6.1 || 4.6.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
+                "phpunit/phpunit": "^8.5.13"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Webmozart\\Assert\\": "src/"
@@ -504,9 +509,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.9.1"
+                "source": "https://github.com/webmozarts/assert/tree/1.10.0"
             },
-            "time": "2020-07-08T17:02:28+00:00"
+            "time": "2021-03-09T10:59:23+00:00"
         }
     ],
     "packages-dev": [
@@ -601,16 +606,16 @@
         },
         {
             "name": "amphp/byte-stream",
-            "version": "v1.8.0",
+            "version": "v1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/byte-stream.git",
-                "reference": "f0c20cf598a958ba2aa8c6e5a71c697d652c7088"
+                "reference": "acbd8002b3536485c997c4e019206b3f10ca15bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/f0c20cf598a958ba2aa8c6e5a71c697d652c7088",
-                "reference": "f0c20cf598a958ba2aa8c6e5a71c697d652c7088",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/acbd8002b3536485c997c4e019206b3f10ca15bd",
+                "reference": "acbd8002b3536485c997c4e019206b3f10ca15bd",
                 "shasum": ""
             },
             "require": {
@@ -666,9 +671,15 @@
             "support": {
                 "irc": "irc://irc.freenode.org/amphp",
                 "issues": "https://github.com/amphp/byte-stream/issues",
-                "source": "https://github.com/amphp/byte-stream/tree/master"
+                "source": "https://github.com/amphp/byte-stream/tree/v1.8.1"
             },
-            "time": "2020-06-29T18:35:05+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-03-30T17:13:30+00:00"
         },
         {
             "name": "composer/package-versions-deprecated",
@@ -826,16 +837,16 @@
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "1.4.5",
+            "version": "1.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "f28d44c286812c714741478d968104c5e604a1d4"
+                "reference": "f27e06cd9675801df441b3656569b328e04aa37c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/f28d44c286812c714741478d968104c5e604a1d4",
-                "reference": "f28d44c286812c714741478d968104c5e604a1d4",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/f27e06cd9675801df441b3656569b328e04aa37c",
+                "reference": "f27e06cd9675801df441b3656569b328e04aa37c",
                 "shasum": ""
             },
             "require": {
@@ -843,7 +854,8 @@
                 "psr/log": "^1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 8"
+                "phpstan/phpstan": "^0.12.55",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
             },
             "type": "library",
             "autoload": {
@@ -869,7 +881,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/xdebug-handler/issues",
-                "source": "https://github.com/composer/xdebug-handler/tree/1.4.5"
+                "source": "https://github.com/composer/xdebug-handler/tree/1.4.6"
             },
             "funding": [
                 {
@@ -885,7 +897,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-13T08:04:11+00:00"
+            "time": "2021-03-25T17:01:18+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -1290,16 +1302,16 @@
         },
         {
             "name": "doctrine/common",
-            "version": "3.1.1",
+            "version": "3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/common.git",
-                "reference": "2afde5a9844126bc311cd5f548b5475e75f800d3"
+                "reference": "a036d90c303f3163b5be8b8fde9b6755b2be4a3a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/common/zipball/2afde5a9844126bc311cd5f548b5475e75f800d3",
-                "reference": "2afde5a9844126bc311cd5f548b5475e75f800d3",
+                "url": "https://api.github.com/repos/doctrine/common/zipball/a036d90c303f3163b5be8b8fde9b6755b2be4a3a",
+                "reference": "a036d90c303f3163b5be8b8fde9b6755b2be4a3a",
                 "shasum": ""
             },
             "require": {
@@ -1312,7 +1324,8 @@
                 "phpstan/phpstan-phpunit": "^0.12",
                 "phpunit/phpunit": "^7.5.20 || ^8.5 || ^9.0",
                 "squizlabs/php_codesniffer": "^3.0",
-                "symfony/phpunit-bridge": "^4.0.5"
+                "symfony/phpunit-bridge": "^4.0.5",
+                "vimeo/psalm": "^4.4"
             },
             "type": "library",
             "autoload": {
@@ -1359,7 +1372,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/common/issues",
-                "source": "https://github.com/doctrine/common/tree/3.1.1"
+                "source": "https://github.com/doctrine/common/tree/3.1.2"
             },
             "funding": [
                 {
@@ -1375,36 +1388,36 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-20T19:58:05+00:00"
+            "time": "2021-02-10T20:18:51+00:00"
         },
         {
             "name": "doctrine/dbal",
-            "version": "2.12.1",
+            "version": "2.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "adce7a954a1c2f14f85e94aed90c8489af204086"
+                "reference": "67d56d3203b33db29834e6b2fcdbfdc50535d796"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/adce7a954a1c2f14f85e94aed90c8489af204086",
-                "reference": "adce7a954a1c2f14f85e94aed90c8489af204086",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/67d56d3203b33db29834e6b2fcdbfdc50535d796",
+                "reference": "67d56d3203b33db29834e6b2fcdbfdc50535d796",
                 "shasum": ""
             },
             "require": {
                 "doctrine/cache": "^1.0",
+                "doctrine/deprecations": "^0.5.3",
                 "doctrine/event-manager": "^1.0",
                 "ext-pdo": "*",
-                "php": "^7.3 || ^8"
+                "php": "^7.1 || ^8"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^8.1",
-                "jetbrains/phpstorm-stubs": "^2019.1",
-                "phpstan/phpstan": "^0.12.40",
-                "phpunit/phpunit": "^9.4",
-                "psalm/plugin-phpunit": "^0.10.0",
+                "doctrine/coding-standard": "8.2.0",
+                "jetbrains/phpstorm-stubs": "2020.2",
+                "phpstan/phpstan": "0.12.81",
+                "phpunit/phpunit": "^7.5.20|^8.5|9.5.0",
                 "symfony/console": "^2.0.5|^3.0|^4.0|^5.0",
-                "vimeo/psalm": "^3.17.2"
+                "vimeo/psalm": "4.6.4"
             },
             "suggest": {
                 "symfony/console": "For helpful console commands such as SQL execution and import of files."
@@ -1413,11 +1426,6 @@
                 "bin/doctrine-dbal"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Doctrine\\DBAL\\": "lib/Doctrine/DBAL"
@@ -1470,7 +1478,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/dbal/issues",
-                "source": "https://github.com/doctrine/dbal/tree/2.12.1"
+                "source": "https://github.com/doctrine/dbal/tree/2.13.0"
             },
             "funding": [
                 {
@@ -1486,20 +1494,63 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-14T20:26:58+00:00"
+            "time": "2021-03-28T18:10:53+00:00"
         },
         {
-            "name": "doctrine/doctrine-bundle",
-            "version": "2.2.3",
+            "name": "doctrine/deprecations",
+            "version": "v0.5.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/doctrine/DoctrineBundle.git",
-                "reference": "015fdd490074d4daa891e2d1df998dc35ba54924"
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "9504165960a1f83cc1480e2be1dd0a0478561314"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/DoctrineBundle/zipball/015fdd490074d4daa891e2d1df998dc35ba54924",
-                "reference": "015fdd490074d4daa891e2d1df998dc35ba54924",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/9504165960a1f83cc1480e2be1dd0a0478561314",
+                "reference": "9504165960a1f83cc1480e2be1dd0a0478561314",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1|^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0|^7.0|^8.0",
+                "phpunit/phpunit": "^7.0|^8.0|^9.0",
+                "psr/log": "^1.0"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "lib/Doctrine/Deprecations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/v0.5.3"
+            },
+            "time": "2021-03-21T12:59:47+00:00"
+        },
+        {
+            "name": "doctrine/doctrine-bundle",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/DoctrineBundle.git",
+                "reference": "8b922578bdee2243a26202b13df795e170efaef8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/DoctrineBundle/zipball/8b922578bdee2243a26202b13df795e170efaef8",
+                "reference": "8b922578bdee2243a26202b13df795e170efaef8",
                 "shasum": ""
             },
             "require": {
@@ -1580,7 +1631,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/DoctrineBundle/issues",
-                "source": "https://github.com/doctrine/DoctrineBundle/tree/2.2.3"
+                "source": "https://github.com/doctrine/DoctrineBundle/tree/2.3.0"
             },
             "funding": [
                 {
@@ -1596,7 +1647,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-19T20:29:53+00:00"
+            "time": "2021-03-16T16:24:04+00:00"
         },
         {
             "name": "doctrine/doctrine-migrations-bundle",
@@ -2026,16 +2077,16 @@
         },
         {
             "name": "doctrine/migrations",
-            "version": "3.1.0",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/migrations.git",
-                "reference": "260991be753a38aa25b6f2d13dbb7f113f8dbf8f"
+                "reference": "e543224170a61ffe49fcadb8e7339c345df1baa2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/migrations/zipball/260991be753a38aa25b6f2d13dbb7f113f8dbf8f",
-                "reference": "260991be753a38aa25b6f2d13dbb7f113f8dbf8f",
+                "url": "https://api.github.com/repos/doctrine/migrations/zipball/e543224170a61ffe49fcadb8e7339c345df1baa2",
+                "reference": "e543224170a61ffe49fcadb8e7339c345df1baa2",
                 "shasum": ""
             },
             "require": {
@@ -2113,7 +2164,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/migrations/issues",
-                "source": "https://github.com/doctrine/migrations/tree/3.1.0"
+                "source": "https://github.com/doctrine/migrations/tree/3.1.1"
             },
             "funding": [
                 {
@@ -2129,20 +2180,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-07T21:16:17+00:00"
+            "time": "2021-03-14T11:10:58+00:00"
         },
         {
             "name": "doctrine/orm",
-            "version": "2.8.2",
+            "version": "2.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/orm.git",
-                "reference": "ebae57eb9637acd8252b398df3121b120688ed5c"
+                "reference": "657a30f8ceef2a78c2ff36a9fe6c6a6717c1c448"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/orm/zipball/ebae57eb9637acd8252b398df3121b120688ed5c",
-                "reference": "ebae57eb9637acd8252b398df3121b120688ed5c",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/657a30f8ceef2a78c2ff36a9fe6c6a6717c1c448",
+                "reference": "657a30f8ceef2a78c2ff36a9fe6c6a6717c1c448",
                 "shasum": ""
             },
             "require": {
@@ -2175,11 +2226,6 @@
                 "bin/doctrine"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.7.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Doctrine\\ORM\\": "lib/Doctrine/ORM"
@@ -2219,9 +2265,9 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/orm/issues",
-                "source": "https://github.com/doctrine/orm/tree/2.8.2"
+                "source": "https://github.com/doctrine/orm/tree/2.8.3"
             },
-            "time": "2021-02-16T22:10:18+00:00"
+            "time": "2021-04-01T21:16:53+00:00"
         },
         {
             "name": "doctrine/persistence",
@@ -2540,16 +2586,16 @@
         },
         {
             "name": "felixfbecker/language-server-protocol",
-            "version": "v1.5.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/felixfbecker/php-language-server-protocol.git",
-                "reference": "85e83cacd2ed573238678c6875f8f0d7ec699541"
+                "reference": "9d846d1f5cf101deee7a61c8ba7caa0a975cd730"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/85e83cacd2ed573238678c6875f8f0d7ec699541",
-                "reference": "85e83cacd2ed573238678c6875f8f0d7ec699541",
+                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/9d846d1f5cf101deee7a61c8ba7caa0a975cd730",
+                "reference": "9d846d1f5cf101deee7a61c8ba7caa0a975cd730",
                 "shasum": ""
             },
             "require": {
@@ -2590,9 +2636,9 @@
             ],
             "support": {
                 "issues": "https://github.com/felixfbecker/php-language-server-protocol/issues",
-                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/v1.5.0"
+                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/1.5.1"
             },
-            "time": "2020-10-23T13:55:30+00:00"
+            "time": "2021-02-22T14:02:09+00:00"
         },
         {
             "name": "friendsofphp/proxy-manager-lts",
@@ -2744,16 +2790,16 @@
         },
         {
             "name": "laminas/laminas-code",
-            "version": "4.0.0",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-code.git",
-                "reference": "28a6d70ea8b8bca687d7163300e611ae33baf82a"
+                "reference": "5b553c274b94af3f880cbaaf8fbab047f279a31c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-code/zipball/28a6d70ea8b8bca687d7163300e611ae33baf82a",
-                "reference": "28a6d70ea8b8bca687d7163300e611ae33baf82a",
+                "url": "https://api.github.com/repos/laminas/laminas-code/zipball/5b553c274b94af3f880cbaaf8fbab047f279a31c",
+                "reference": "5b553c274b94af3f880cbaaf8fbab047f279a31c",
                 "shasum": ""
             },
             "require": {
@@ -2811,20 +2857,20 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-12-30T16:16:14+00:00"
+            "time": "2021-03-27T13:55:31+00:00"
         },
         {
             "name": "laminas/laminas-eventmanager",
-            "version": "3.3.0",
+            "version": "3.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-eventmanager.git",
-                "reference": "1940ccf30e058b2fd66f5a9d696f1b5e0027b082"
+                "reference": "966c859b67867b179fde1eff0cd38df51472ce4a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/1940ccf30e058b2fd66f5a9d696f1b5e0027b082",
-                "reference": "1940ccf30e058b2fd66f5a9d696f1b5e0027b082",
+                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/966c859b67867b179fde1eff0cd38df51472ce4a",
+                "reference": "966c859b67867b179fde1eff0cd38df51472ce4a",
                 "shasum": ""
             },
             "require": {
@@ -2846,12 +2892,6 @@
                 "laminas/laminas-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.3.x-dev",
-                    "dev-develop": "3.4.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Laminas\\EventManager\\": "src/"
@@ -2883,28 +2923,30 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-08-25T11:10:44+00:00"
+            "time": "2021-03-08T15:24:29+00:00"
         },
         {
             "name": "laminas/laminas-zendframework-bridge",
-            "version": "1.1.1",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
-                "reference": "6ede70583e101030bcace4dcddd648f760ddf642"
+                "reference": "6cccbddfcfc742eb02158d6137ca5687d92cee32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/6ede70583e101030bcace4dcddd648f760ddf642",
-                "reference": "6ede70583e101030bcace4dcddd648f760ddf642",
+                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/6cccbddfcfc742eb02158d6137ca5687d92cee32",
+                "reference": "6cccbddfcfc742eb02158d6137ca5687d92cee32",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0 || ^8.0"
+                "php": "^7.3 || ^8.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.1 || ^9.3",
-                "squizlabs/php_codesniffer": "^3.5"
+                "psalm/plugin-phpunit": "^0.15.1",
+                "squizlabs/php_codesniffer": "^3.5",
+                "vimeo/psalm": "^4.6"
             },
             "type": "library",
             "extra": {
@@ -2943,20 +2985,20 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-09-14T14:23:00+00:00"
+            "time": "2021-02-25T21:54:58+00:00"
         },
         {
             "name": "laravel/framework",
-            "version": "v8.28.1",
+            "version": "v8.35.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "73dd43d92fcde6c6abc00658ae33391397ca119d"
+                "reference": "d118c0df39e7524131176aaf76493eae63a8a602"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/73dd43d92fcde6c6abc00658ae33391397ca119d",
-                "reference": "73dd43d92fcde6c6abc00658ae33391397ca119d",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/d118c0df39e7524131176aaf76493eae63a8a602",
+                "reference": "d118c0df39e7524131176aaf76493eae63a8a602",
                 "shasum": ""
             },
             "require": {
@@ -3064,7 +3106,7 @@
                 "phpunit/phpunit": "Required to use assertions and run tests (^8.5.8|^9.3.3).",
                 "predis/predis": "Required to use the predis connector (^1.1.2).",
                 "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
-                "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^4.0).",
+                "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^4.0|^5.0).",
                 "symfony/cache": "Required to PSR-6 cache bridge (^5.1.4).",
                 "symfony/filesystem": "Required to enable support for relative symbolic links (^5.1.4).",
                 "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^2.0).",
@@ -3111,7 +3153,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2021-02-16T18:07:44+00:00"
+            "time": "2021-03-30T21:34:17+00:00"
         },
         {
             "name": "laravel/lumen-framework",
@@ -3212,16 +3254,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "1.5.7",
+            "version": "1.5.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "11df9b36fd4f1d2b727a73bf14931d81373b9a54"
+                "reference": "08fa59b8e4e34ea8a773d55139ae9ac0e0aecbaf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/11df9b36fd4f1d2b727a73bf14931d81373b9a54",
-                "reference": "11df9b36fd4f1d2b727a73bf14931d81373b9a54",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/08fa59b8e4e34ea8a773d55139ae9ac0e0aecbaf",
+                "reference": "08fa59b8e4e34ea8a773d55139ae9ac0e0aecbaf",
                 "shasum": ""
             },
             "require": {
@@ -3309,7 +3351,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-31T13:49:32+00:00"
+            "time": "2021-03-28T18:51:39+00:00"
         },
         {
             "name": "league/flysystem",
@@ -3618,16 +3660,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "2.45.1",
+            "version": "2.46.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "528783b188bdb853eb21239b1722831e0f000a8d"
+                "reference": "2fd2c4a77d58a4e95234c8a61c5df1f157a91bf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/528783b188bdb853eb21239b1722831e0f000a8d",
-                "reference": "528783b188bdb853eb21239b1722831e0f000a8d",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/2fd2c4a77d58a4e95234c8a61c5df1f157a91bf4",
+                "reference": "2fd2c4a77d58a4e95234c8a61c5df1f157a91bf4",
                 "shasum": ""
             },
             "require": {
@@ -3707,7 +3749,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-11T18:30:17+00:00"
+            "time": "2021-02-24T17:30:44+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
@@ -4046,16 +4088,16 @@
         },
         {
             "name": "phar-io/version",
-            "version": "3.0.4",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "e4782611070e50613683d2b9a57730e9a3ba5451"
+                "reference": "bae7c545bef187884426f042434e561ab1ddb182"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/e4782611070e50613683d2b9a57730e9a3ba5451",
-                "reference": "e4782611070e50613683d2b9a57730e9a3ba5451",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/bae7c545bef187884426f042434e561ab1ddb182",
+                "reference": "bae7c545bef187884426f042434e561ab1ddb182",
                 "shasum": ""
             },
             "require": {
@@ -4091,9 +4133,9 @@
             "description": "Library for handling version information and constraints",
             "support": {
                 "issues": "https://github.com/phar-io/version/issues",
-                "source": "https://github.com/phar-io/version/tree/3.0.4"
+                "source": "https://github.com/phar-io/version/tree/3.1.0"
             },
-            "time": "2020-12-13T23:18:30+00:00"
+            "time": "2021-02-23T14:00:09+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -4324,16 +4366,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.12.2",
+            "version": "1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "245710e971a030f42e08f4912863805570f23d39"
+                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/245710e971a030f42e08f4912863805570f23d39",
-                "reference": "245710e971a030f42e08f4912863805570f23d39",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/be1996ed8adc35c3fd795488a653f4b518be70ea",
+                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea",
                 "shasum": ""
             },
             "require": {
@@ -4385,9 +4427,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/1.12.2"
+                "source": "https://github.com/phpspec/prophecy/tree/1.13.0"
             },
-            "time": "2020-12-19T10:15:11+00:00"
+            "time": "2021-03-17T13:42:18+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
@@ -4444,16 +4486,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.5",
+            "version": "9.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "f3e026641cc91909d421802dd3ac7827ebfd97e1"
+                "reference": "f6293e1b30a2354e8428e004689671b83871edde"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f3e026641cc91909d421802dd3ac7827ebfd97e1",
-                "reference": "f3e026641cc91909d421802dd3ac7827ebfd97e1",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f6293e1b30a2354e8428e004689671b83871edde",
+                "reference": "f6293e1b30a2354e8428e004689671b83871edde",
                 "shasum": ""
             },
             "require": {
@@ -4509,7 +4551,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.5"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.6"
             },
             "funding": [
                 {
@@ -4517,7 +4559,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-28T06:44:49+00:00"
+            "time": "2021-03-28T07:26:59+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -4762,16 +4804,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.2",
+            "version": "9.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f661659747f2f87f9e72095bb207bceb0f151cb4"
+                "reference": "c73c6737305e779771147af66c96ca6a7ed8a741"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f661659747f2f87f9e72095bb207bceb0f151cb4",
-                "reference": "f661659747f2f87f9e72095bb207bceb0f151cb4",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c73c6737305e779771147af66c96ca6a7ed8a741",
+                "reference": "c73c6737305e779771147af66c96ca6a7ed8a741",
                 "shasum": ""
             },
             "require": {
@@ -4849,7 +4891,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.2"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.4"
             },
             "funding": [
                 {
@@ -4861,7 +4903,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-02-02T14:45:58+00:00"
+            "time": "2021-03-23T07:16:29+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -4974,27 +5016,22 @@
         },
         {
             "name": "psr/container",
-            "version": "1.0.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=7.2.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -5007,7 +5044,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common Container Interface (PHP FIG PSR-11)",
@@ -5021,9 +5058,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/master"
+                "source": "https://github.com/php-fig/container/tree/1.1.1"
             },
-            "time": "2017-02-14T16:28:37+00:00"
+            "time": "2021-03-05T17:36:06+00:00"
         },
         {
             "name": "psr/event-dispatcher",
@@ -6214,20 +6251,20 @@
         },
         {
             "name": "swiftmailer/swiftmailer",
-            "version": "v6.2.5",
+            "version": "v6.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/swiftmailer/swiftmailer.git",
-                "reference": "698a6a9f54d7eb321274de3ad19863802c879fb7"
+                "reference": "15f7faf8508e04471f666633addacf54c0ab5933"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/698a6a9f54d7eb321274de3ad19863802c879fb7",
-                "reference": "698a6a9f54d7eb321274de3ad19863802c879fb7",
+                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/15f7faf8508e04471f666633addacf54c0ab5933",
+                "reference": "15f7faf8508e04471f666633addacf54c0ab5933",
                 "shasum": ""
             },
             "require": {
-                "egulias/email-validator": "^2.0",
+                "egulias/email-validator": "^2.0|^3.1",
                 "php": ">=7.0.0",
                 "symfony/polyfill-iconv": "^1.0",
                 "symfony/polyfill-intl-idn": "^1.10",
@@ -6273,7 +6310,7 @@
             ],
             "support": {
                 "issues": "https://github.com/swiftmailer/swiftmailer/issues",
-                "source": "https://github.com/swiftmailer/swiftmailer/tree/v6.2.5"
+                "source": "https://github.com/swiftmailer/swiftmailer/tree/v6.2.7"
             },
             "funding": [
                 {
@@ -6285,25 +6322,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-12T09:35:59+00:00"
+            "time": "2021-03-09T12:30:35+00:00"
         },
         {
             "name": "symfony/cache",
-            "version": "v5.2.3",
+            "version": "v5.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "d6aed6c1bbf6f59e521f46437475a0ff4878d388"
+                "reference": "093d69bb10c959553c8beb828b8d4ea250a247dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/d6aed6c1bbf6f59e521f46437475a0ff4878d388",
-                "reference": "d6aed6c1bbf6f59e521f46437475a0ff4878d388",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/093d69bb10c959553c8beb828b8d4ea250a247dd",
+                "reference": "093d69bb10c959553c8beb828b8d4ea250a247dd",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
-                "psr/cache": "~1.0",
+                "psr/cache": "^1.0|^2.0",
                 "psr/log": "^1.1",
                 "symfony/cache-contracts": "^1.1.7|^2",
                 "symfony/polyfill-php80": "^1.15",
@@ -6317,9 +6354,9 @@
                 "symfony/var-dumper": "<4.4"
             },
             "provide": {
-                "psr/cache-implementation": "1.0",
+                "psr/cache-implementation": "1.0|2.0",
                 "psr/simple-cache-implementation": "1.0",
-                "symfony/cache-implementation": "1.0"
+                "symfony/cache-implementation": "1.0|2.0"
             },
             "require-dev": {
                 "cache/integration-tests": "dev-master",
@@ -6364,7 +6401,7 @@
                 "psr6"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache/tree/v5.2.3"
+                "source": "https://github.com/symfony/cache/tree/v5.2.6"
             },
             "funding": [
                 {
@@ -6380,7 +6417,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-27T11:24:50+00:00"
+            "time": "2021-03-16T09:10:13+00:00"
         },
         {
             "name": "symfony/cache-contracts",
@@ -6463,16 +6500,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v5.2.3",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "50e0e1314a3b2609d32b6a5a0d0fb5342494c4ab"
+                "reference": "212d54675bf203ff8aef7d8cee8eecfb72f4a263"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/50e0e1314a3b2609d32b6a5a0d0fb5342494c4ab",
-                "reference": "50e0e1314a3b2609d32b6a5a0d0fb5342494c4ab",
+                "url": "https://api.github.com/repos/symfony/config/zipball/212d54675bf203ff8aef7d8cee8eecfb72f4a263",
+                "reference": "212d54675bf203ff8aef7d8cee8eecfb72f4a263",
                 "shasum": ""
             },
             "require": {
@@ -6521,7 +6558,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v5.2.3"
+                "source": "https://github.com/symfony/config/tree/v5.2.4"
             },
             "funding": [
                 {
@@ -6537,20 +6574,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-27T10:15:41+00:00"
+            "time": "2021-02-23T23:58:19+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v5.2.3",
+            "version": "v5.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "89d4b176d12a2946a1ae4e34906a025b7b6b135a"
+                "reference": "35f039df40a3b335ebf310f244cb242b3a83ac8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/89d4b176d12a2946a1ae4e34906a025b7b6b135a",
-                "reference": "89d4b176d12a2946a1ae4e34906a025b7b6b135a",
+                "url": "https://api.github.com/repos/symfony/console/zipball/35f039df40a3b335ebf310f244cb242b3a83ac8d",
+                "reference": "35f039df40a3b335ebf310f244cb242b3a83ac8d",
                 "shasum": ""
             },
             "require": {
@@ -6618,7 +6655,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.2.3"
+                "source": "https://github.com/symfony/console/tree/v5.2.6"
             },
             "funding": [
                 {
@@ -6634,11 +6671,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-28T22:06:19+00:00"
+            "time": "2021-03-28T09:42:18+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v5.2.3",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
@@ -6683,7 +6720,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v5.2.3"
+                "source": "https://github.com/symfony/css-selector/tree/v5.2.4"
             },
             "funding": [
                 {
@@ -6703,16 +6740,16 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v5.2.3",
+            "version": "v5.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "62f72187be689540385dce6c68a5d4c16f034139"
+                "reference": "1e66194bed2a69fa395d26bf1067e5e34483afac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/62f72187be689540385dce6c68a5d4c16f034139",
-                "reference": "62f72187be689540385dce6c68a5d4c16f034139",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/1e66194bed2a69fa395d26bf1067e5e34483afac",
+                "reference": "1e66194bed2a69fa395d26bf1067e5e34483afac",
                 "shasum": ""
             },
             "require": {
@@ -6730,7 +6767,7 @@
             },
             "provide": {
                 "psr/container-implementation": "1.0",
-                "symfony/service-implementation": "1.0"
+                "symfony/service-implementation": "1.0|2.0"
             },
             "require-dev": {
                 "symfony/config": "^5.1",
@@ -6770,7 +6807,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v5.2.3"
+                "source": "https://github.com/symfony/dependency-injection/tree/v5.2.6"
             },
             "funding": [
                 {
@@ -6786,7 +6823,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-27T12:56:27+00:00"
+            "time": "2021-03-22T11:10:24+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -6857,16 +6894,16 @@
         },
         {
             "name": "symfony/doctrine-bridge",
-            "version": "v5.2.3",
+            "version": "v5.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/doctrine-bridge.git",
-                "reference": "c348e596f49df406a7c0a51443864038b3137cac"
+                "reference": "72b6d743c6108e2b8d15ab94e1a8a224c4d0d144"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/c348e596f49df406a7c0a51443864038b3137cac",
-                "reference": "c348e596f49df406a7c0a51443864038b3137cac",
+                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/72b6d743c6108e2b8d15ab94e1a8a224c4d0d144",
+                "reference": "72b6d743c6108e2b8d15ab94e1a8a224c4d0d144",
                 "shasum": ""
             },
             "require": {
@@ -6951,7 +6988,7 @@
             "description": "Provides integration for Doctrine with various Symfony components",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/doctrine-bridge/tree/v5.2.3"
+                "source": "https://github.com/symfony/doctrine-bridge/tree/v5.2.6"
             },
             "funding": [
                 {
@@ -6967,20 +7004,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-03T04:42:09+00:00"
+            "time": "2021-03-10T22:10:15+00:00"
         },
         {
             "name": "symfony/error-handler",
-            "version": "v5.2.3",
+            "version": "v5.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "48f18b3609e120ea66d59142c23dc53e9562c26d"
+                "reference": "bdb7fb4188da7f4211e4b88350ba0dfdad002b03"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/48f18b3609e120ea66d59142c23dc53e9562c26d",
-                "reference": "48f18b3609e120ea66d59142c23dc53e9562c26d",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/bdb7fb4188da7f4211e4b88350ba0dfdad002b03",
+                "reference": "bdb7fb4188da7f4211e4b88350ba0dfdad002b03",
                 "shasum": ""
             },
             "require": {
@@ -7020,7 +7057,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v5.2.3"
+                "source": "https://github.com/symfony/error-handler/tree/v5.2.6"
             },
             "funding": [
                 {
@@ -7036,20 +7073,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-28T22:06:19+00:00"
+            "time": "2021-03-16T09:07:47+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v5.2.3",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "4f9760f8074978ad82e2ce854dff79a71fe45367"
+                "reference": "d08d6ec121a425897951900ab692b612a61d6240"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/4f9760f8074978ad82e2ce854dff79a71fe45367",
-                "reference": "4f9760f8074978ad82e2ce854dff79a71fe45367",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/d08d6ec121a425897951900ab692b612a61d6240",
+                "reference": "d08d6ec121a425897951900ab692b612a61d6240",
                 "shasum": ""
             },
             "require": {
@@ -7105,7 +7142,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v5.2.3"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v5.2.4"
             },
             "funding": [
                 {
@@ -7121,7 +7158,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-27T10:36:42+00:00"
+            "time": "2021-02-18T17:12:37+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -7204,16 +7241,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.2.3",
+            "version": "v5.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "262d033b57c73e8b59cd6e68a45c528318b15038"
+                "reference": "8c86a82f51658188119e62cff0a050a12d09836f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/262d033b57c73e8b59cd6e68a45c528318b15038",
-                "reference": "262d033b57c73e8b59cd6e68a45c528318b15038",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/8c86a82f51658188119e62cff0a050a12d09836f",
+                "reference": "8c86a82f51658188119e62cff0a050a12d09836f",
                 "shasum": ""
             },
             "require": {
@@ -7246,7 +7283,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.2.3"
+                "source": "https://github.com/symfony/filesystem/tree/v5.2.6"
             },
             "funding": [
                 {
@@ -7262,20 +7299,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-27T10:01:46+00:00"
+            "time": "2021-03-28T14:30:26+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v5.2.3",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "4adc8d172d602008c204c2e16956f99257248e03"
+                "reference": "0d639a0943822626290d169965804f79400e6a04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/4adc8d172d602008c204c2e16956f99257248e03",
-                "reference": "4adc8d172d602008c204c2e16956f99257248e03",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/0d639a0943822626290d169965804f79400e6a04",
+                "reference": "0d639a0943822626290d169965804f79400e6a04",
                 "shasum": ""
             },
             "require": {
@@ -7307,7 +7344,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.2.3"
+                "source": "https://github.com/symfony/finder/tree/v5.2.4"
             },
             "funding": [
                 {
@@ -7323,20 +7360,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-28T22:06:19+00:00"
+            "time": "2021-02-15T18:55:04+00:00"
         },
         {
             "name": "symfony/framework-bundle",
-            "version": "v5.2.3",
+            "version": "v5.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/framework-bundle.git",
-                "reference": "ff455b2afd3f98237d4131ffebe190e59cc0f011"
+                "reference": "8889da18c6faa76c6149a90e6542be4afe723f2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/ff455b2afd3f98237d4131ffebe190e59cc0f011",
-                "reference": "ff455b2afd3f98237d4131ffebe190e59cc0f011",
+                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/8889da18c6faa76c6149a90e6542be4afe723f2f",
+                "reference": "8889da18c6faa76c6149a90e6542be4afe723f2f",
                 "shasum": ""
             },
             "require": {
@@ -7363,7 +7400,7 @@
                 "phpunit/phpunit": "<5.4.3",
                 "symfony/asset": "<5.1",
                 "symfony/browser-kit": "<4.4",
-                "symfony/console": "<5.2",
+                "symfony/console": "<5.2.5",
                 "symfony/dom-crawler": "<4.4",
                 "symfony/dotenv": "<5.1",
                 "symfony/form": "<5.2",
@@ -7406,6 +7443,7 @@
                 "symfony/process": "^4.4|^5.0",
                 "symfony/property-info": "^4.4|^5.0",
                 "symfony/security-bundle": "^5.1",
+                "symfony/security-core": "^4.4|^5.2",
                 "symfony/security-csrf": "^4.4|^5.0",
                 "symfony/security-http": "^4.4|^5.0",
                 "symfony/serializer": "^5.2",
@@ -7455,7 +7493,7 @@
             "description": "Provides a tight integration between Symfony components and the Symfony full-stack framework",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/framework-bundle/tree/v5.2.3"
+                "source": "https://github.com/symfony/framework-bundle/tree/v5.2.6"
             },
             "funding": [
                 {
@@ -7471,7 +7509,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-27T11:19:04+00:00"
+            "time": "2021-03-22T14:43:01+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
@@ -7554,16 +7592,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v5.2.3",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "20c554c0f03f7cde5ce230ed248470cccbc34c36"
+                "reference": "54499baea7f7418bce7b5ec92770fd0799e8e9bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/20c554c0f03f7cde5ce230ed248470cccbc34c36",
-                "reference": "20c554c0f03f7cde5ce230ed248470cccbc34c36",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/54499baea7f7418bce7b5ec92770fd0799e8e9bf",
+                "reference": "54499baea7f7418bce7b5ec92770fd0799e8e9bf",
                 "shasum": ""
             },
             "require": {
@@ -7607,7 +7645,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v5.2.3"
+                "source": "https://github.com/symfony/http-foundation/tree/v5.2.4"
             },
             "funding": [
                 {
@@ -7623,20 +7661,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-03T04:42:09+00:00"
+            "time": "2021-02-25T17:16:57+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v5.2.3",
+            "version": "v5.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "89bac04f29e7b0b52f9fa6a4288ca7a8f90a1a05"
+                "reference": "f34de4c61ca46df73857f7f36b9a3805bdd7e3b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/89bac04f29e7b0b52f9fa6a4288ca7a8f90a1a05",
-                "reference": "89bac04f29e7b0b52f9fa6a4288ca7a8f90a1a05",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/f34de4c61ca46df73857f7f36b9a3805bdd7e3b2",
+                "reference": "f34de4c61ca46df73857f7f36b9a3805bdd7e3b2",
                 "shasum": ""
             },
             "require": {
@@ -7671,7 +7709,7 @@
                 "psr/log-implementation": "1.0"
             },
             "require-dev": {
-                "psr/cache": "~1.0",
+                "psr/cache": "^1.0|^2.0|^3.0",
                 "symfony/browser-kit": "^4.4|^5.0",
                 "symfony/config": "^5.0",
                 "symfony/console": "^4.4|^5.0",
@@ -7719,7 +7757,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v5.2.3"
+                "source": "https://github.com/symfony/http-kernel/tree/v5.2.6"
             },
             "funding": [
                 {
@@ -7735,20 +7773,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-03T04:51:58+00:00"
+            "time": "2021-03-29T05:16:58+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v5.2.3",
+            "version": "v5.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "7dee6a43493f39b51ff6c5bb2bd576fe40a76c86"
+                "reference": "1b2092244374cbe48ae733673f2ca0818b37197b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/7dee6a43493f39b51ff6c5bb2bd576fe40a76c86",
-                "reference": "7dee6a43493f39b51ff6c5bb2bd576fe40a76c86",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/1b2092244374cbe48ae733673f2ca0818b37197b",
+                "reference": "1b2092244374cbe48ae733673f2ca0818b37197b",
                 "shasum": ""
             },
             "require": {
@@ -7759,12 +7797,13 @@
                 "symfony/polyfill-php80": "^1.15"
             },
             "conflict": {
+                "egulias/email-validator": "~3.0.0",
                 "phpdocumentor/reflection-docblock": "<3.2.2",
                 "phpdocumentor/type-resolver": "<1.4.0",
                 "symfony/mailer": "<4.4"
             },
             "require-dev": {
-                "egulias/email-validator": "^2.1.10",
+                "egulias/email-validator": "^2.1.10|^3.1",
                 "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
                 "symfony/dependency-injection": "^4.4|^5.0",
                 "symfony/property-access": "^4.4|^5.1",
@@ -7801,7 +7840,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v5.2.3"
+                "source": "https://github.com/symfony/mime/tree/v5.2.6"
             },
             "funding": [
                 {
@@ -7817,7 +7856,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-02T06:10:15+00:00"
+            "time": "2021-03-12T13:18:39+00:00"
         },
         {
             "name": "symfony/orm-pack",
@@ -8518,7 +8557,7 @@
         },
         {
             "name": "symfony/process",
-            "version": "v5.2.3",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
@@ -8560,7 +8599,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.2.3"
+                "source": "https://github.com/symfony/process/tree/v5.2.4"
             },
             "funding": [
                 {
@@ -8580,7 +8619,7 @@
         },
         {
             "name": "symfony/proxy-manager-bridge",
-            "version": "v5.2.3",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/proxy-manager-bridge.git",
@@ -8627,7 +8666,7 @@
             "description": "Provides integration for ProxyManager with various Symfony components",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/proxy-manager-bridge/tree/v5.2.3"
+                "source": "https://github.com/symfony/proxy-manager-bridge/tree/v5.2.4"
             },
             "funding": [
                 {
@@ -8647,16 +8686,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v5.2.3",
+            "version": "v5.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "348b5917e56546c6d96adbf21d7f92c9ef563661"
+                "reference": "31fba555f178afd04d54fd26953501b2c3f0c6e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/348b5917e56546c6d96adbf21d7f92c9ef563661",
-                "reference": "348b5917e56546c6d96adbf21d7f92c9ef563661",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/31fba555f178afd04d54fd26953501b2c3f0c6e6",
+                "reference": "31fba555f178afd04d54fd26953501b2c3f0c6e6",
                 "shasum": ""
             },
             "require": {
@@ -8717,7 +8756,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v5.2.3"
+                "source": "https://github.com/symfony/routing/tree/v5.2.6"
             },
             "funding": [
                 {
@@ -8733,7 +8772,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-27T10:15:41+00:00"
+            "time": "2021-03-14T13:53:33+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -8816,7 +8855,7 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v5.2.3",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
@@ -8858,7 +8897,7 @@
             "description": "Provides a way to profile code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v5.2.3"
+                "source": "https://github.com/symfony/stopwatch/tree/v5.2.4"
             },
             "funding": [
                 {
@@ -8878,16 +8917,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.2.3",
+            "version": "v5.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "c95468897f408dd0aca2ff582074423dd0455122"
+                "reference": "ad0bd91bce2054103f5eaa18ebeba8d3bc2a0572"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/c95468897f408dd0aca2ff582074423dd0455122",
-                "reference": "c95468897f408dd0aca2ff582074423dd0455122",
+                "url": "https://api.github.com/repos/symfony/string/zipball/ad0bd91bce2054103f5eaa18ebeba8d3bc2a0572",
+                "reference": "ad0bd91bce2054103f5eaa18ebeba8d3bc2a0572",
                 "shasum": ""
             },
             "require": {
@@ -8941,7 +8980,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.2.3"
+                "source": "https://github.com/symfony/string/tree/v5.2.6"
             },
             "funding": [
                 {
@@ -8957,20 +8996,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-25T15:14:59+00:00"
+            "time": "2021-03-17T17:12:15+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v5.2.3",
+            "version": "v5.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "c021864d4354ee55160ddcfd31dc477a1bc77949"
+                "reference": "2cc7f45d96db9adfcf89adf4401d9dfed509f4e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/c021864d4354ee55160ddcfd31dc477a1bc77949",
-                "reference": "c021864d4354ee55160ddcfd31dc477a1bc77949",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/2cc7f45d96db9adfcf89adf4401d9dfed509f4e1",
+                "reference": "2cc7f45d96db9adfcf89adf4401d9dfed509f4e1",
                 "shasum": ""
             },
             "require": {
@@ -8987,7 +9026,7 @@
                 "symfony/yaml": "<4.4"
             },
             "provide": {
-                "symfony/translation-implementation": "2.0"
+                "symfony/translation-implementation": "2.3"
             },
             "require-dev": {
                 "psr/log": "~1.0",
@@ -9034,7 +9073,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v5.2.3"
+                "source": "https://github.com/symfony/translation/tree/v5.2.6"
             },
             "funding": [
                 {
@@ -9050,7 +9089,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-27T10:15:41+00:00"
+            "time": "2021-03-23T19:33:48+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -9132,16 +9171,16 @@
         },
         {
             "name": "symfony/twig-bridge",
-            "version": "v5.2.3",
+            "version": "v5.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/twig-bridge.git",
-                "reference": "3e8a56f4a8ab4db819f5ec726afad29d470b452d"
+                "reference": "a65d8d38c66f147f29b73d53d14e8c9a983653b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/3e8a56f4a8ab4db819f5ec726afad29d470b452d",
-                "reference": "3e8a56f4a8ab4db819f5ec726afad29d470b452d",
+                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/a65d8d38c66f147f29b73d53d14e8c9a983653b8",
+                "reference": "a65d8d38c66f147f29b73d53d14e8c9a983653b8",
                 "shasum": ""
             },
             "require": {
@@ -9161,7 +9200,7 @@
                 "symfony/workflow": "<5.2"
             },
             "require-dev": {
-                "egulias/email-validator": "^2.1.10",
+                "egulias/email-validator": "^2.1.10|^3",
                 "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
                 "symfony/asset": "^4.4|^5.0",
                 "symfony/console": "^4.4|^5.0",
@@ -9171,6 +9210,7 @@
                 "symfony/form": "^5.1.9",
                 "symfony/http-foundation": "^4.4|^5.0",
                 "symfony/http-kernel": "^4.4|^5.0",
+                "symfony/intl": "^4.4|^5.0",
                 "symfony/mime": "^5.2",
                 "symfony/polyfill-intl-icu": "~1.0",
                 "symfony/property-info": "^4.4|^5.1",
@@ -9185,9 +9225,9 @@
                 "symfony/web-link": "^4.4|^5.0",
                 "symfony/workflow": "^5.2",
                 "symfony/yaml": "^4.4|^5.0",
-                "twig/cssinliner-extra": "^2.12",
-                "twig/inky-extra": "^2.12",
-                "twig/markdown-extra": "^2.12"
+                "twig/cssinliner-extra": "^2.12|^3",
+                "twig/inky-extra": "^2.12|^3",
+                "twig/markdown-extra": "^2.12|^3"
             },
             "suggest": {
                 "symfony/asset": "For using the AssetExtension",
@@ -9231,7 +9271,7 @@
             "description": "Provides integration for Twig with various Symfony components",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/twig-bridge/tree/v5.2.3"
+                "source": "https://github.com/symfony/twig-bridge/tree/v5.2.6"
             },
             "funding": [
                 {
@@ -9247,11 +9287,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-03T04:42:09+00:00"
+            "time": "2021-03-16T09:10:13+00:00"
         },
         {
             "name": "symfony/twig-bundle",
-            "version": "v5.2.3",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/twig-bundle.git",
@@ -9318,7 +9358,7 @@
             "description": "Provides a tight integration of Twig into the Symfony full-stack framework",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/twig-bundle/tree/v5.2.3"
+                "source": "https://github.com/symfony/twig-bundle/tree/v5.2.4"
             },
             "funding": [
                 {
@@ -9383,16 +9423,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v5.2.3",
+            "version": "v5.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "72ca213014a92223a5d18651ce79ef441c12b694"
+                "reference": "89412a68ea2e675b4e44f260a5666729f77f668e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/72ca213014a92223a5d18651ce79ef441c12b694",
-                "reference": "72ca213014a92223a5d18651ce79ef441c12b694",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/89412a68ea2e675b4e44f260a5666729f77f668e",
+                "reference": "89412a68ea2e675b4e44f260a5666729f77f668e",
                 "shasum": ""
             },
             "require": {
@@ -9451,7 +9491,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v5.2.3"
+                "source": "https://github.com/symfony/var-dumper/tree/v5.2.6"
             },
             "funding": [
                 {
@@ -9467,11 +9507,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-27T10:15:41+00:00"
+            "time": "2021-03-28T09:42:18+00:00"
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v5.2.3",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
@@ -9524,7 +9564,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v5.2.3"
+                "source": "https://github.com/symfony/var-exporter/tree/v5.2.4"
             },
             "funding": [
                 {
@@ -9801,16 +9841,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "4.6.4",
+            "version": "4.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "97fe86c4e158b5a57c5150aa5055c38b5a809aab"
+                "reference": "d4377c0baf3ffbf0b1ec6998e8d1be2a40971005"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/97fe86c4e158b5a57c5150aa5055c38b5a809aab",
-                "reference": "97fe86c4e158b5a57c5150aa5055c38b5a809aab",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/d4377c0baf3ffbf0b1ec6998e8d1be2a40971005",
+                "reference": "d4377c0baf3ffbf0b1ec6998e8d1be2a40971005",
                 "shasum": ""
             },
             "require": {
@@ -9852,6 +9892,7 @@
                 "slevomat/coding-standard": "^6.3.11",
                 "squizlabs/php_codesniffer": "^3.5",
                 "symfony/process": "^4.3",
+                "weirdan/phpunit-appveyor-reporter": "^1.0.0",
                 "weirdan/prophecy-shim": "^1.0 || ^2.0"
             },
             "suggest": {
@@ -9899,9 +9940,9 @@
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/4.6.4"
+                "source": "https://github.com/vimeo/psalm/tree/4.7.0"
             },
-            "time": "2021-03-16T23:28:18+00:00"
+            "time": "2021-03-29T03:54:38+00:00"
         },
         {
             "name": "vlucas/phpdotenv",

--- a/known-issues.xml
+++ b/known-issues.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.6.4@97fe86c4e158b5a57c5150aa5055c38b5a809aab">
+<files psalm-version="4.7.0@d4377c0baf3ffbf0b1ec6998e8d1be2a40971005">
   <file src="src/Agent.php">
     <MixedArgument occurrences="12">
       <code>$config-&gt;get(ConfigKey::MONITORING_ENABLED)</code>
@@ -75,6 +75,12 @@
     <MixedPropertyFetch occurrences="1">
       <code>$this-&gt;connectionAddress</code>
     </MixedPropertyFetch>
+    <UnusedClosureParam occurrences="1">
+      <code>$context</code>
+    </UnusedClosureParam>
+    <UnusedFunctionCall occurrences="1">
+      <code>socket_shutdown</code>
+    </UnusedFunctionCall>
   </file>
   <file src="src/CoreAgent/Manifest.php">
     <MixedArrayAccess occurrences="3">
@@ -177,6 +183,9 @@
     <UndefinedClass occurrences="1">
       <code>$app-&gt;make(self::CONFIG_SERVICE_KEY)</code>
     </UndefinedClass>
+    <UnusedClosureParam occurrences="1">
+      <code>$event</code>
+    </UnusedClosureParam>
   </file>
   <file src="src/Logger/FilteredLogLevelDecorator.php">
     <MixedArrayOffset occurrences="1">
@@ -468,6 +477,9 @@
       <code>$tagRequest</code>
       <code>$tagRequest</code>
     </MixedAssignment>
+    <UnusedVariable occurrences="1">
+      <code>$block</code>
+    </UnusedVariable>
   </file>
   <file src="tests/Unit/Events/Span/SpanReferenceTest.php">
     <MixedAssignment occurrences="1">
@@ -487,6 +499,11 @@
       <code>$version</code>
     </MixedAssignment>
   </file>
+  <file src="tests/Unit/Helper/MemoryUsageTest.php">
+    <UnusedVariable occurrences="1">
+      <code>$block</code>
+    </UnusedVariable>
+  </file>
   <file src="tests/Unit/Helper/TimerTest.php">
     <DeprecatedMethod occurrences="2">
       <code>self::assertRegExp(self::DATE_FORMAT_VALIDATION_REGEX, (string) $timer-&gt;getStart())</code>
@@ -498,12 +515,21 @@
       <code>testFacadeProxiesMethodsToRealAgent</code>
     </PossiblyInvalidArgument>
   </file>
+  <file src="tests/Unit/Laravel/Middleware/ActionInstrumentTest.php">
+    <UnusedClosureParam occurrences="3">
+      <code>$originalName</code>
+      <code>$originalName</code>
+      <code>$originalName</code>
+    </UnusedClosureParam>
+  </file>
+  <file src="tests/Unit/Laravel/Middleware/MiddlewareInstrumentTest.php">
+    <UnusedClosureParam occurrences="2">
+      <code>$name</code>
+      <code>$type</code>
+    </UnusedClosureParam>
+  </file>
   <file src="tests/Unit/Laravel/Providers/ScoutApmServiceProviderTest.php">
-    <DeprecatedClass occurrences="1">
-      <code>self::at(3)</code>
-    </DeprecatedClass>
-    <DeprecatedMethod occurrences="2">
-      <code>self::at(3)</code>
+    <DeprecatedMethod occurrences="1">
       <code>setMethods</code>
     </DeprecatedMethod>
     <InvalidArrayOffset occurrences="1">
@@ -516,6 +542,17 @@
       <code>$commands[1]['StartSpan']['operation']</code>
       <code>json_decode(json_encode($metadata), true)['ApplicationEvent']</code>
     </MixedArrayAccess>
+    <UnusedClosureParam occurrences="1">
+      <code>$whichViews</code>
+    </UnusedClosureParam>
+  </file>
+  <file src="tests/Unit/Laravel/View/Engine/ScoutViewEngineDecoratorTest.php">
+    <UnusedClosureParam occurrences="4">
+      <code>$name</code>
+      <code>$name</code>
+      <code>$type</code>
+      <code>$type</code>
+    </UnusedClosureParam>
   </file>
   <file src="tests/Unit/ScoutApmBundle/DependencyInjection/ScoutApmExtensionTest.php">
     <MixedArgument occurrences="1">
@@ -545,5 +582,17 @@
     <MixedAssignment occurrences="1">
       <code>$flattenedMetadata</code>
     </MixedAssignment>
+  </file>
+  <file src="tests/Unit/ScoutApmBundle/Twig/TwigDecoratorTest.php">
+    <UnusedClosureParam occurrences="8">
+      <code>$name</code>
+      <code>$name</code>
+      <code>$name</code>
+      <code>$name</code>
+      <code>$type</code>
+      <code>$type</code>
+      <code>$type</code>
+      <code>$type</code>
+    </UnusedClosureParam>
   </file>
 </files>

--- a/known-issues.xml
+++ b/known-issues.xml
@@ -528,10 +528,7 @@
       <code>$type</code>
     </UnusedClosureParam>
   </file>
-  <file src="tests/Unit/Laravel/Providers/ScoutApmServiceProviderTest.php">
-    <DeprecatedMethod occurrences="1">
-      <code>setMethods</code>
-    </DeprecatedMethod>
+  <file src="tests/Unit/Laravel/Providers/ScoutApmServiceProviderTestBase.php">
     <InvalidArrayOffset occurrences="1">
       <code>$commands[1]['StartSpan']</code>
     </InvalidArrayOffset>
@@ -542,9 +539,36 @@
       <code>$commands[1]['StartSpan']['operation']</code>
       <code>json_decode(json_encode($metadata), true)['ApplicationEvent']</code>
     </MixedArrayAccess>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$this-&gt;application</code>
+    </PossiblyInvalidArgument>
+    <UndefinedClass occurrences="6">
+      <code>$events</code>
+      <code>$events</code>
+      <code>$events</code>
+      <code>$events</code>
+      <code>$events</code>
+      <code>$events</code>
+    </UndefinedClass>
     <UnusedClosureParam occurrences="1">
       <code>$whichViews</code>
     </UnusedClosureParam>
+  </file>
+  <file src="tests/Unit/Laravel/Providers/ScoutApmServiceProviderUsingLaravelTest.php">
+    <DeprecatedMethod occurrences="1">
+      <code>setMethods</code>
+    </DeprecatedMethod>
+  </file>
+  <file src="tests/Unit/Laravel/Providers/ScoutApmServiceProviderUsingLumenTest.php">
+    <DeprecatedMethod occurrences="1">
+      <code>setMethods</code>
+    </DeprecatedMethod>
+    <MixedArrayAssignment occurrences="1">
+      <code>$loadedConfigurations['cache']</code>
+    </MixedArrayAssignment>
+    <MixedAssignment occurrences="1">
+      <code>$loadedConfigurations</code>
+    </MixedAssignment>
   </file>
   <file src="tests/Unit/Laravel/View/Engine/ScoutViewEngineDecoratorTest.php">
     <UnusedClosureParam occurrences="4">

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -37,6 +37,10 @@
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory>./src/</directory>
+            <exclude>
+                <file>./src/ScoutApmBundle/Twig/TwigMethods-Twig2.php</file>
+                <file>./src/ScoutApmBundle/Twig/TwigMethods-Twig3.php</file>
+            </exclude>
         </whitelist>
     </filter>
     <listeners>

--- a/src/Laravel/Providers/ScoutApmServiceProvider.php
+++ b/src/Laravel/Providers/ScoutApmServiceProvider.php
@@ -173,13 +173,13 @@ final class ScoutApmServiceProvider extends ServiceProvider
         try {
             $connection = $application->make('db')->connection();
             $this->instrumentDatabaseQueries($agent, $connection);
-        } catch (BindingResolutionException $bindingResolutionException) {
+        } catch (Throwable $exception) {
             $log->info(
                 sprintf(
                     'Could not set up DB instrumentation: %s',
-                    $bindingResolutionException->getMessage()
+                    $exception->getMessage()
                 ),
-                ['exception' => $bindingResolutionException]
+                ['exception' => $exception]
             );
         }
 

--- a/src/Laravel/Providers/ScoutApmServiceProvider.php
+++ b/src/Laravel/Providers/ScoutApmServiceProvider.php
@@ -170,9 +170,19 @@ final class ScoutApmServiceProvider extends ServiceProvider
             $runningInConsole = $application->runningInConsole();
         }
 
-        if ($application->has('connection')) {
-            $connection = $application->make('connection');
+        try {
+            $connection = $application->make('db')->connection();
             $this->instrumentDatabaseQueries($agent, $connection);
+        } catch (BindingResolutionException $bindingResolutionException) {
+            $log->info(
+                sprintf(
+                    'Could not set up DB instrumentation: %s',
+                    $bindingResolutionException->getMessage()
+                ),
+                [
+                    'exception' => $bindingResolutionException,
+                ]
+            );
         }
 
         if ($agent->shouldInstrument(self::INSTRUMENT_LARAVEL_QUEUES)) {

--- a/src/Laravel/Providers/ScoutApmServiceProvider.php
+++ b/src/Laravel/Providers/ScoutApmServiceProvider.php
@@ -7,6 +7,7 @@ namespace Scoutapm\Laravel\Providers;
 use Illuminate\Cache\CacheManager;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Http\Kernel as HttpKernelInterface;
@@ -73,7 +74,7 @@ final class ScoutApmServiceProvider extends ServiceProvider
             ));
         });
 
-        $this->app->singleton(self::CACHE_SERVICE_KEY, static function (Application $app) {
+        $this->app->singleton(self::CACHE_SERVICE_KEY, static function (Container $app) {
             try {
                 return $app->make(CacheManager::class)->store();
             } catch (Throwable $anything) {
@@ -81,14 +82,14 @@ final class ScoutApmServiceProvider extends ServiceProvider
             }
         });
 
-        $this->app->singleton(FilteredLogLevelDecorator::class, static function (Application $app) {
+        $this->app->singleton(FilteredLogLevelDecorator::class, static function (Container $app) {
             return new FilteredLogLevelDecorator(
                 $app->make('log'),
                 $app->make(self::CONFIG_SERVICE_KEY)->get(ConfigKey::LOG_LEVEL)
             );
         });
 
-        $this->app->singleton(ScoutApmAgent::class, static function (Application $app) {
+        $this->app->singleton(ScoutApmAgent::class, static function (Container $app) {
             return Agent::fromConfig(
                 $app->make(self::CONFIG_SERVICE_KEY),
                 $app->make(FilteredLogLevelDecorator::class),

--- a/src/Laravel/Providers/ScoutApmServiceProvider.php
+++ b/src/Laravel/Providers/ScoutApmServiceProvider.php
@@ -179,9 +179,7 @@ final class ScoutApmServiceProvider extends ServiceProvider
                     'Could not set up DB instrumentation: %s',
                     $bindingResolutionException->getMessage()
                 ),
-                [
-                    'exception' => $bindingResolutionException,
-                ]
+                ['exception' => $bindingResolutionException]
             );
         }
 

--- a/src/Laravel/Providers/ScoutApmServiceProvider.php
+++ b/src/Laravel/Providers/ScoutApmServiceProvider.php
@@ -31,6 +31,9 @@ use Scoutapm\Laravel\Middleware\IgnoredEndpoints;
 use Scoutapm\Laravel\Middleware\MiddlewareInstrument;
 use Scoutapm\Laravel\Middleware\SendRequestToScout;
 use Scoutapm\Laravel\Queue\JobQueueListener;
+use Scoutapm\Laravel\Router\AutomaticallyDetermineControllerName;
+use Scoutapm\Laravel\Router\DetermineLaravelControllerName;
+use Scoutapm\Laravel\Router\DetermineLumenControllerName;
 use Scoutapm\Laravel\View\Engine\ScoutViewEngineDecorator;
 use Scoutapm\Logger\FilteredLogLevelDecorator;
 use Scoutapm\ScoutApmAgent;
@@ -97,6 +100,14 @@ final class ScoutApmServiceProvider extends ServiceProvider
                 $app->make(FilteredLogLevelDecorator::class),
                 $app->make(self::CACHE_SERVICE_KEY)
             );
+        });
+
+        $this->app->singleton(AutomaticallyDetermineControllerName::class, function (Container $app) {
+            if ($this->isLumen($app)) {
+                return $app->make(DetermineLumenControllerName::class);
+            }
+
+            return $app->make(DetermineLaravelControllerName::class);
         });
 
         $this->app->afterResolving('view.engine.resolver', function (EngineResolver $engineResolver): void {

--- a/src/Laravel/Router/AutomaticallyDetermineControllerName.php
+++ b/src/Laravel/Router/AutomaticallyDetermineControllerName.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scoutapm\Laravel\Router;
+
+use Illuminate\Http\Request;
+
+interface AutomaticallyDetermineControllerName
+{
+    public function __invoke(Request $request): string;
+}

--- a/src/Laravel/Router/DetermineLaravelControllerName.php
+++ b/src/Laravel/Router/DetermineLaravelControllerName.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scoutapm\Laravel\Router;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Router;
+use Scoutapm\Logger\FilteredLogLevelDecorator;
+use Throwable;
+use Webmozart\Assert\Assert;
+
+final class DetermineLaravelControllerName implements AutomaticallyDetermineControllerName
+{
+    /** @var FilteredLogLevelDecorator */
+    private $logger;
+    /** @var Router */
+    private $router;
+
+    public function __construct(FilteredLogLevelDecorator $logger, Router $router)
+    {
+        $this->logger = $logger;
+        $this->router = $router;
+    }
+
+    // @todo needs tests
+    public function __invoke(Request $request): string
+    {
+        $name = 'unknown';
+
+        try {
+            $route = $this->router->current();
+            if ($route !== null) {
+                /** @var mixed $name */
+                $name = $route->action['controller'] ?? $route->uri();
+                Assert::stringNotEmpty($name);
+            }
+        } catch (Throwable $e) {
+            $this->logger->debug(
+                'Exception obtaining name of Laravel endpoint: ' . $e->getMessage(),
+                ['exception' => $e]
+            );
+        }
+
+        return 'Controller/' . $name;
+    }
+}

--- a/src/Laravel/Router/DetermineLaravelControllerName.php
+++ b/src/Laravel/Router/DetermineLaravelControllerName.php
@@ -23,7 +23,6 @@ final class DetermineLaravelControllerName implements AutomaticallyDetermineCont
         $this->router = $router;
     }
 
-    // @todo needs tests
     public function __invoke(Request $request): string
     {
         $name = 'unknown';

--- a/src/Laravel/Router/DetermineLumenControllerName.php
+++ b/src/Laravel/Router/DetermineLumenControllerName.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scoutapm\Laravel\Router;
+
+use Closure;
+use Illuminate\Http\Request;
+use Laravel\Lumen\Routing\Router;
+use ReflectionFunction;
+use Scoutapm\Logger\FilteredLogLevelDecorator;
+use Throwable;
+
+use function array_key_exists;
+use function basename;
+use function count;
+use function get_class;
+use function is_array;
+use function is_callable;
+use function is_object;
+use function is_string;
+use function sprintf;
+use function trim;
+
+final class DetermineLumenControllerName implements AutomaticallyDetermineControllerName
+{
+    /** @var FilteredLogLevelDecorator */
+    private $logger;
+    /** @var Router */
+    private $router;
+
+    public function __construct(FilteredLogLevelDecorator $logger, Router $router)
+    {
+        $this->logger = $logger;
+        $this->router = $router;
+    }
+
+    // @todo needs tests
+    public function __invoke(Request $request): string
+    {
+        $name = 'unknown';
+
+        try {
+            $route = $request->getMethod() . '/' . trim($request->getPathInfo(), '/');
+
+            $lumenRouteConfiguration = $this->router->getRoutes();
+
+            if (array_key_exists($route, $lumenRouteConfiguration)) {
+                $matchedRoute = $lumenRouteConfiguration[$route];
+
+                if (array_key_exists('action', $matchedRoute)) {
+                    $matchedRouteAction = $matchedRoute['action'];
+
+                    if (array_key_exists('as', $matchedRouteAction)) {
+                        $name = $matchedRouteAction['as'];
+                    }
+
+                    if (array_key_exists('uses', $matchedRouteAction)) {
+                        $name = $matchedRouteAction['uses'];
+                    }
+
+                    if (
+                        is_callable($matchedRouteAction)
+                        || (is_array($matchedRouteAction) && count($matchedRouteAction) === 2)
+                    ) {
+                        if (is_string($matchedRouteAction)) {
+                            $name = $matchedRouteAction;
+                        }
+
+                        if (is_array($matchedRoute['action'])) {
+                            $name = sprintf(
+                                '%s@%s',
+                                is_object($matchedRouteAction[0]) ? get_class($matchedRouteAction[0]) : trim($matchedRouteAction[0]),
+                                trim($matchedRouteAction[1])
+                            );
+                        }
+                    }
+
+                    if (is_array($matchedRouteAction) && array_key_exists(0, $matchedRouteAction) && $matchedRouteAction[0] instanceof Closure) {
+                        $function = new ReflectionFunction($matchedRouteAction[0]);
+                        $name     = sprintf(
+                            'closure_%s@%d',
+                            basename($function->getFileName()),
+                            $function->getStartLine()
+                        );
+                    }
+                }
+            }
+        } catch (Throwable $e) {
+            $this->logger->debug(
+                'Exception obtaining name of Lumen endpoint: ' . $e->getMessage(),
+                ['exception' => $e]
+            );
+        }
+
+        return 'Controller/' . $name;
+    }
+}

--- a/tests/Unit/Laravel/Providers/ScoutApmServiceProviderTest.php
+++ b/tests/Unit/Laravel/Providers/ScoutApmServiceProviderTest.php
@@ -16,6 +16,7 @@ use Illuminate\Contracts\Queue\Job;
 use Illuminate\Contracts\View\Engine;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Connection;
+use Illuminate\Database\DatabaseManager;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Http\Kernel as HttpKernelImplementation;
 use Illuminate\Queue\Events\JobProcessed;
@@ -289,8 +290,13 @@ final class ScoutApmServiceProviderTest extends TestCase
             ->method('listen')
             ->with(self::isInstanceOf(Closure::class));
 
-        $this->application->singleton('connection', function () {
-            return $this->connection;
+        $dbManager = $this->createMock(DatabaseManager::class);
+        $dbManager->expects(self::once())
+            ->method('connection')
+            ->willReturn($this->connection);
+
+        $this->application->singleton('db', static function () use ($dbManager) {
+            return $dbManager;
         });
 
         $this->bootServiceProvider();

--- a/tests/Unit/Laravel/Providers/ScoutApmServiceProviderTestBase.php
+++ b/tests/Unit/Laravel/Providers/ScoutApmServiceProviderTestBase.php
@@ -6,39 +6,33 @@ namespace Scoutapm\UnitTests\Laravel\Providers;
 
 use Closure;
 use Illuminate\Cache\ArrayStore;
-use Illuminate\Cache\CacheManager;
 use Illuminate\Cache\Repository as CacheRepository;
 use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Http\Kernel as HttpKernelInterface;
 use Illuminate\Contracts\Queue\Job;
-use Illuminate\Contracts\View\Engine;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Connection;
 use Illuminate\Database\DatabaseManager;
-use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Application as LaravelApplication;
 use Illuminate\Foundation\Http\Kernel as HttpKernelImplementation;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
-use Illuminate\Routing\Router;
 use Illuminate\View\Engines\EngineResolver;
-use Illuminate\View\Factory as ViewFactory;
+use Laravel\Lumen\Application as LumenApplication;
 use PHPUnit\Framework\Constraint\IsType;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
-use Psr\Log\LogLevel;
 use ReflectionException;
 use ReflectionProperty;
 use Scoutapm\Agent;
-use Scoutapm\Cache\DevNullCache;
 use Scoutapm\Config;
 use Scoutapm\Connector\Command;
 use Scoutapm\Connector\Connector;
 use Scoutapm\Events\Metadata;
 use Scoutapm\Extension\PotentiallyAvailableExtensionCapabilities;
-use Scoutapm\Extension\Version;
 use Scoutapm\Laravel\Middleware\ActionInstrument;
 use Scoutapm\Laravel\Middleware\IgnoredEndpoints;
 use Scoutapm\Laravel\Middleware\MiddlewareInstrument;
@@ -53,19 +47,19 @@ use function assert;
 use function json_decode;
 use function json_encode;
 use function putenv;
-use function sprintf;
-use function sys_get_temp_dir;
 use function uniqid;
 
-/** @covers \Scoutapm\Laravel\Providers\ScoutApmServiceProvider */
-final class ScoutApmServiceProviderTest extends TestCase
+abstract class ScoutApmServiceProviderTestBase extends TestCase
 {
     private const CONFIG_SERVICE_KEY = ScoutApmAgent::class . '_config';
     private const CACHE_SERVICE_KEY  = ScoutApmAgent::class . '_cache';
 
-    private const VIEW_ENGINES_TO_WRAP = ['file', 'php', 'blade'];
+    protected const VIEW_ENGINES_TO_WRAP = ['file', 'php', 'blade'];
 
-    /** @var Application&MockObject */
+    /**
+     * @var LumenApplication|LaravelApplication
+     * @psalm-var LumenApplication|LaravelApplication&MockObject
+     */
     private $application;
 
     /** @var ScoutApmServiceProvider */
@@ -78,9 +72,10 @@ final class ScoutApmServiceProviderTest extends TestCase
     {
         parent::setUp();
 
-        $this->application = $this->createLaravelApplicationFulfillingBasicRequirementsForScout();
+        $this->application = $this->createFrameworkApplicationFulfillingBasicRequirementsForScout();
         $this->connection  = $this->createMock(Connection::class);
 
+        /** @psalm-suppress PossiblyInvalidArgument */
         $this->serviceProvider = new ScoutApmServiceProvider($this->application);
     }
 
@@ -124,29 +119,6 @@ final class ScoutApmServiceProviderTest extends TestCase
 
         self::assertInstanceOf(CacheRepository::class, $cacheUsed);
         self::assertInstanceOf(ArrayStore::class, $cacheUsed->getStore());
-    }
-
-    /**
-     * @throws BindingResolutionException
-     * @throws ReflectionException
-     */
-    public function testScoutAgentUsesDevNullCacheWhenNoCacheIsConfigured(): void
-    {
-        $laravelVersion = Version::fromString(Application::VERSION);
-        if (! $laravelVersion->isOlderThan(Version::fromString('8.0.0'))) {
-            self::markTestSkipped('Laravel 8 always seems to configure a cache now');
-
-            return;
-        }
-
-        $this->serviceProvider->register();
-        $agent = $this->application->make(ScoutApmAgent::class);
-
-        $cacheProperty = new ReflectionProperty($agent, 'cache');
-        $cacheProperty->setAccessible(true);
-        $cacheUsed = $cacheProperty->getValue($agent);
-
-        self::assertInstanceOf(DevNullCache::class, $cacheUsed);
     }
 
     /**
@@ -238,6 +210,10 @@ final class ScoutApmServiceProviderTest extends TestCase
     /** @throws Throwable */
     public function testMiddlewareAreRegisteredOnBootForHttpRequest(): void
     {
+        if (! $this->application instanceof LaravelApplication) {
+            self::markTestSkipped('Middleware are only injected for Laravel applications');
+        }
+
         $kernel = $this->application->make(HttpKernelInterface::class);
         assert($kernel instanceof HttpKernelImplementation);
 
@@ -259,8 +235,13 @@ final class ScoutApmServiceProviderTest extends TestCase
     /** @throws Throwable */
     public function testMiddlewareAreNotRegisteredOnBootForConsoleRequest(): void
     {
-        $this->application = $this->createLaravelApplicationFulfillingBasicRequirementsForScout(true);
+        if (! $this->application instanceof LaravelApplication) {
+            self::markTestSkipped('Middleware are only injected for Laravel applications');
+        }
 
+        $this->application = $this->createFrameworkApplicationFulfillingBasicRequirementsForScout(true);
+
+        /** @psalm-suppress PossiblyInvalidArgument */
         $this->serviceProvider = new ScoutApmServiceProvider($this->application);
 
         $kernel = $this->application->make(HttpKernelInterface::class);
@@ -305,7 +286,9 @@ final class ScoutApmServiceProviderTest extends TestCase
     /** @throws Throwable */
     public function testJobQueueIsInstrumentedWhenRunningInConsole(): void
     {
-        $this->application     = $this->createLaravelApplicationFulfillingBasicRequirementsForScout(true);
+        $this->application = $this->createFrameworkApplicationFulfillingBasicRequirementsForScout(true);
+
+        /** @psalm-suppress PossiblyInvalidArgument */
         $this->serviceProvider = new ScoutApmServiceProvider($this->application);
         $this->serviceProvider->register();
 
@@ -395,7 +378,7 @@ final class ScoutApmServiceProviderTest extends TestCase
     /** @throws Throwable */
     public function testJobQueuesAreNotInstrumentedWhenNotConfigured(): void
     {
-        $this->application     = $this->createLaravelApplicationFulfillingBasicRequirementsForScout(true);
+        $this->application     = $this->createFrameworkApplicationFulfillingBasicRequirementsForScout(true);
         $this->serviceProvider = new ScoutApmServiceProvider($this->application);
 
         $this->application->singleton('config', static function () {
@@ -517,108 +500,9 @@ final class ScoutApmServiceProviderTest extends TestCase
      * Helper to create a Laravel application instance that has very basic wiring up of services that our Laravel
      * binding library actually interacts with in some way.
      *
-     * @psalm-return Application&MockObject
+     * @return LumenApplication|LaravelApplication
+     *
+     * @psalm-return LumenApplication|LaravelApplication&MockObject
      */
-    private function createLaravelApplicationFulfillingBasicRequirementsForScout(bool $runningInConsole = false): Application
-    {
-        $application = $this->getMockBuilder(Application::class)
-            ->setMethods(['runningInConsole'])
-            ->getMock();
-
-        $application
-            ->method('runningInConsole')
-            ->willReturn($runningInConsole);
-
-        $application->singleton(
-            LoggerInterface::class,
-            function (): LoggerInterface {
-                return $this->createMock(LoggerInterface::class);
-            }
-        );
-        $application->alias(LoggerInterface::class, 'log');
-
-        $application->singleton(
-            FilteredLogLevelDecorator::class,
-            static function () use ($application): FilteredLogLevelDecorator {
-                return new FilteredLogLevelDecorator(
-                    $application->make(LoggerInterface::class),
-                    LogLevel::DEBUG
-                );
-            }
-        );
-
-        $application->singleton(
-            HttpKernelInterface::class,
-            function () use ($application): HttpKernelInterface {
-                return new HttpKernelImplementation($application, $this->createMock(Router::class));
-            }
-        );
-
-        $application->singleton(
-            'view',
-            function (): ViewFactory {
-                return $this->createMock(ViewFactory::class);
-            }
-        );
-
-        $application->singleton(
-            'view.engine.resolver',
-            function (): EngineResolver {
-                $viewEngineResolver = new EngineResolver();
-
-                foreach (self::VIEW_ENGINES_TO_WRAP as $viewEngineName) {
-                    $viewEngineResolver->register(
-                        $viewEngineName,
-                        function () use ($viewEngineName): Engine {
-                            return new class ($viewEngineName) implements Engine {
-                                /** @var string */
-                                private $viewEngineName;
-
-                                public function __construct(string $viewEngineName)
-                                {
-                                    $this->viewEngineName = $viewEngineName;
-                                }
-
-                                /** @inheritDoc */
-                                public function get($path, array $data = []): string
-                                {
-                                    return sprintf(
-                                        'Fake view engine for [%s] - rendered path "%s"',
-                                        $this->viewEngineName,
-                                        $path
-                                    );
-                                }
-                            };
-                        }
-                    );
-                }
-
-                return $viewEngineResolver;
-            }
-        );
-
-        $application->singleton(
-            'cache',
-            static function () use ($application): CacheManager {
-                return new CacheManager($application);
-            }
-        );
-
-        // Older versions of Laravel used `path.config` service name for path...
-        $application->singleton(
-            'path.config',
-            static function (): string {
-                return sys_get_temp_dir();
-            }
-        );
-
-        $application->singleton(
-            'config',
-            static function (): ConfigRepository {
-                return new ConfigRepository();
-            }
-        );
-
-        return $application;
-    }
+    abstract protected function createFrameworkApplicationFulfillingBasicRequirementsForScout(bool $runningInConsole = false): Container;
 }

--- a/tests/Unit/Laravel/Providers/ScoutApmServiceProviderTestBase.php
+++ b/tests/Unit/Laravel/Providers/ScoutApmServiceProviderTestBase.php
@@ -158,6 +158,7 @@ abstract class ScoutApmServiceProviderTestBase extends TestCase
     public function testViewEngineResolversHaveBeenWrapped(): void
     {
         $this->serviceProvider->register();
+        $this->bootServiceProvider();
 
         $templateName = uniqid('test_template_name', true);
 

--- a/tests/Unit/Laravel/Providers/ScoutApmServiceProviderUsingLaravelTest.php
+++ b/tests/Unit/Laravel/Providers/ScoutApmServiceProviderUsingLaravelTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scoutapm\UnitTests\Laravel\Providers;
+
+use Illuminate\Cache\CacheManager;
+use Illuminate\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Http\Kernel as HttpKernelInterface;
+use Illuminate\Contracts\View\Engine;
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Http\Kernel as HttpKernelImplementation;
+use Illuminate\Routing\Router;
+use Illuminate\View\Engines\EngineResolver;
+use Illuminate\View\Factory as ViewFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Scoutapm\Logger\FilteredLogLevelDecorator;
+
+use function class_exists;
+use function sprintf;
+use function sys_get_temp_dir;
+
+/** @covers \Scoutapm\Laravel\Providers\ScoutApmServiceProvider */
+final class ScoutApmServiceProviderUsingLaravelTest extends ScoutApmServiceProviderTestBase
+{
+    /**
+     * Helper to create a Laravel application instance that has very basic wiring up of services that our Laravel
+     * binding library actually interacts with in some way.
+     *
+     * @psalm-return Application&MockObject
+     */
+    protected function createFrameworkApplicationFulfillingBasicRequirementsForScout(bool $runningInConsole = false): Container
+    {
+        if (! class_exists(Application::class)) {
+            self::markTestSkipped(Application::class . ' is not available in the current dependency tree');
+        }
+
+        $application = $this->getMockBuilder(Application::class)
+            ->setMethods(['runningInConsole'])
+            ->getMock();
+
+        $application
+            ->method('runningInConsole')
+            ->willReturn($runningInConsole);
+
+        $application->singleton(
+            LoggerInterface::class,
+            function (): LoggerInterface {
+                return $this->createMock(LoggerInterface::class);
+            }
+        );
+        $application->alias(LoggerInterface::class, 'log');
+
+        $application->singleton(
+            FilteredLogLevelDecorator::class,
+            static function () use ($application): FilteredLogLevelDecorator {
+                return new FilteredLogLevelDecorator(
+                    $application->make(LoggerInterface::class),
+                    LogLevel::DEBUG
+                );
+            }
+        );
+
+        $application->singleton(
+            HttpKernelInterface::class,
+            function () use ($application): HttpKernelInterface {
+                return new HttpKernelImplementation($application, $this->createMock(Router::class));
+            }
+        );
+
+        $application->singleton(
+            'view',
+            function (): ViewFactory {
+                return $this->createMock(ViewFactory::class);
+            }
+        );
+
+        $application->singleton(
+            'view.engine.resolver',
+            function (): EngineResolver {
+                $viewEngineResolver = new EngineResolver();
+
+                foreach (self::VIEW_ENGINES_TO_WRAP as $viewEngineName) {
+                    $viewEngineResolver->register(
+                        $viewEngineName,
+                        function () use ($viewEngineName): Engine {
+                            return new class ($viewEngineName) implements Engine {
+                                /** @var string */
+                                private $viewEngineName;
+
+                                public function __construct(string $viewEngineName)
+                                {
+                                    $this->viewEngineName = $viewEngineName;
+                                }
+
+                                /** @inheritDoc */
+                                public function get($path, array $data = []): string
+                                {
+                                    return sprintf(
+                                        'Fake view engine for [%s] - rendered path "%s"',
+                                        $this->viewEngineName,
+                                        $path
+                                    );
+                                }
+                            };
+                        }
+                    );
+                }
+
+                return $viewEngineResolver;
+            }
+        );
+
+        $application->singleton(
+            'cache',
+            static function () use ($application): CacheManager {
+                return new CacheManager($application);
+            }
+        );
+
+        // Older versions of Laravel used `path.config` service name for path...
+        $application->singleton(
+            'path.config',
+            static function (): string {
+                return sys_get_temp_dir();
+            }
+        );
+
+        $application->singleton(
+            'config',
+            static function (): ConfigRepository {
+                return new ConfigRepository();
+            }
+        );
+
+        return $application;
+    }
+}

--- a/tests/Unit/Laravel/Providers/ScoutApmServiceProviderUsingLumenTest.php
+++ b/tests/Unit/Laravel/Providers/ScoutApmServiceProviderUsingLumenTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scoutapm\UnitTests\Laravel\Providers;
+
+use Illuminate\Cache\CacheManager;
+use Illuminate\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\View\Engine;
+use Illuminate\View\Engines\EngineResolver;
+use Illuminate\View\Factory as ViewFactory;
+use Laravel\Lumen\Application;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use ReflectionProperty;
+use Scoutapm\Logger\FilteredLogLevelDecorator;
+
+use function class_exists;
+use function sprintf;
+use function sys_get_temp_dir;
+
+/** @covers \Scoutapm\Laravel\Providers\ScoutApmServiceProvider */
+final class ScoutApmServiceProviderUsingLumenTest extends ScoutApmServiceProviderTestBase
+{
+    /**
+     * Helper to create a Laravel application instance that has very basic wiring up of services that our Laravel
+     * binding library actually interacts with in some way.
+     *
+     * @psalm-return Application&MockObject
+     */
+    protected function createFrameworkApplicationFulfillingBasicRequirementsForScout(bool $runningInConsole = false): Container
+    {
+        if (! class_exists(Application::class)) {
+            self::markTestSkipped(Application::class . ' is not available in the current dependency tree');
+        }
+
+        $application = $this->getMockBuilder(Application::class)
+            ->setMethods(['runningInConsole'])
+            ->getMock();
+
+        $application
+            ->method('runningInConsole')
+            ->willReturn($runningInConsole);
+
+        /**
+         * This property write is needed otherwise Lumen overwrites any configuration already done if the key is not
+         * set, thus breaking our expectations.
+         *
+         * @see \Laravel\Lumen\Application::configure()
+         */
+        $loadedConfigurationsProperty = new ReflectionProperty($application, 'loadedConfigurations');
+        $loadedConfigurationsProperty->setAccessible(true);
+        $loadedConfigurations          = $loadedConfigurationsProperty->getValue($application);
+        $loadedConfigurations['cache'] = true;
+        $loadedConfigurationsProperty->setValue($application, $loadedConfigurations);
+
+        $application->instance('app', $application);
+        $application->alias(
+            \Illuminate\Contracts\Foundation\Application::class,
+            'app'
+        );
+
+        $application->singleton(
+            LoggerInterface::class,
+            function (): LoggerInterface {
+                return $this->createMock(LoggerInterface::class);
+            }
+        );
+        $application->alias(LoggerInterface::class, 'log');
+
+        $application->singleton(
+            FilteredLogLevelDecorator::class,
+            static function () use ($application): FilteredLogLevelDecorator {
+                return new FilteredLogLevelDecorator(
+                    $application->make(LoggerInterface::class),
+                    LogLevel::DEBUG
+                );
+            }
+        );
+
+        $application->singleton(
+            'view',
+            function (): ViewFactory {
+                return $this->createMock(ViewFactory::class);
+            }
+        );
+
+        $application->singleton(
+            'view.engine.resolver',
+            function (): EngineResolver {
+                $viewEngineResolver = new EngineResolver();
+
+                foreach (self::VIEW_ENGINES_TO_WRAP as $viewEngineName) {
+                    $viewEngineResolver->register(
+                        $viewEngineName,
+                        function () use ($viewEngineName): Engine {
+                            return new class ($viewEngineName) implements Engine {
+                                /** @var string */
+                                private $viewEngineName;
+
+                                public function __construct(string $viewEngineName)
+                                {
+                                    $this->viewEngineName = $viewEngineName;
+                                }
+
+                                /** @inheritDoc */
+                                public function get($path, array $data = []): string
+                                {
+                                    return sprintf(
+                                        'Fake view engine for [%s] - rendered path "%s"',
+                                        $this->viewEngineName,
+                                        $path
+                                    );
+                                }
+                            };
+                        }
+                    );
+                }
+
+                return $viewEngineResolver;
+            }
+        );
+
+        $application->singleton(
+            CacheManager::class,
+            static function () use ($application): CacheManager {
+                /** @noinspection PhpParamsInspection */
+                /** @psalm-suppress InvalidArgument */
+
+                return new CacheManager($application);
+            }
+        );
+        $application->alias('cache', CacheManager::class);
+
+        // Older versions of Laravel used `path.config` service name for path...
+        $application->singleton(
+            'path.config',
+            static function (): string {
+                return sys_get_temp_dir();
+            }
+        );
+
+        $application->singleton(
+            'config',
+            static function (): ConfigRepository {
+                return new ConfigRepository();
+            }
+        );
+
+        return $application;
+    }
+}

--- a/tests/Unit/Laravel/Providers/ScoutApmServiceProviderUsingLumenTest.php
+++ b/tests/Unit/Laravel/Providers/ScoutApmServiceProviderUsingLumenTest.php
@@ -80,6 +80,7 @@ final class ScoutApmServiceProviderUsingLumenTest extends ScoutApmServiceProvide
             }
         );
 
+        $application->make('view');
         $application->singleton(
             'view',
             function (): ViewFactory {
@@ -148,6 +149,15 @@ final class ScoutApmServiceProviderUsingLumenTest extends ScoutApmServiceProvide
                 return new ConfigRepository();
             }
         );
+
+        /**
+         * For some reason, if we don't `make` these services first, the tests fail in Lumen 5.5.*. Which is
+         * very odd, since in those cases, we're overwriting it immediately after. Without lengthy investigation into
+         * the depths of Lumen, I don't know the exact reason for this, but it may just be a bug solved in later
+         * versions, or some unclear magic.
+         */
+        $application->make('db');
+        $application->make('config');
 
         return $application;
     }

--- a/tests/Unit/Laravel/Router/DetermineLaravelControllerNameTest.php
+++ b/tests/Unit/Laravel/Router/DetermineLaravelControllerNameTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scoutapm\UnitTests\Laravel\Router;
+
+use Exception;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
+use Illuminate\Routing\Router;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Scoutapm\Laravel\Router\DetermineLaravelControllerName;
+use Scoutapm\Logger\FilteredLogLevelDecorator;
+
+use function uniqid;
+
+/** @covers \Scoutapm\Laravel\Router\DetermineLaravelControllerName */
+final class DetermineLaravelControllerNameTest extends TestCase
+{
+    private const EXPECTED_CONTROLLER_PREFIX = 'Controller/';
+
+    /** @var LoggerInterface&MockObject */
+    private $logger;
+    /** @var Router&MockObject */
+    private $router;
+    /** @var DetermineLaravelControllerName */
+    private $determineControllerName;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->router = $this->createMock(Router::class);
+
+        $this->determineControllerName = new DetermineLaravelControllerName(
+            new FilteredLogLevelDecorator($this->logger, LogLevel::DEBUG),
+            $this->router
+        );
+    }
+
+    public function testControllerNameIsReturnedWhenRouteHasControllerKey(): void
+    {
+        $controllerName = uniqid('controllerName', true);
+
+        $this->router->expects(self::once())
+            ->method('current')
+            ->willReturn(new Route('GET', '/default-url', ['controller' => $controllerName]));
+
+        self::assertSame(
+            self::EXPECTED_CONTROLLER_PREFIX . $controllerName,
+            $this->determineControllerName->__invoke(new Request())
+        );
+    }
+
+    public function testUrlIsReturnedWhenRouteHasControllerKey(): void
+    {
+        $url = uniqid('url', true);
+
+        $this->router->expects(self::once())
+            ->method('current')
+            ->willReturn(new Route('GET', $url, []));
+
+        self::assertSame(
+            self::EXPECTED_CONTROLLER_PREFIX . $url,
+            $this->determineControllerName->__invoke(new Request())
+        );
+    }
+
+    public function testUnknownIsReturnedWhenNoRouteFound(): void
+    {
+        $this->router->expects(self::once())
+            ->method('current')
+            ->willReturn(null);
+
+        self::assertSame(
+            self::EXPECTED_CONTROLLER_PREFIX . 'unknown',
+            $this->determineControllerName->__invoke(new Request())
+        );
+    }
+
+    public function testUnknownIsReturnedAndExceptionLoggedWhenRouterThrowsException(): void
+    {
+        $this->router->expects(self::once())
+            ->method('current')
+            ->willThrowException(new Exception('oh no'));
+
+        $this->logger->expects(self::once())
+            ->method('log')
+            ->with(
+                LogLevel::DEBUG,
+                '[Scout] Exception obtaining name of Laravel endpoint: oh no'
+            );
+
+        self::assertSame(
+            self::EXPECTED_CONTROLLER_PREFIX . 'unknown',
+            $this->determineControllerName->__invoke(new Request())
+        );
+    }
+}

--- a/tests/Unit/Laravel/Router/DetermineLaravelControllerNameTest.php
+++ b/tests/Unit/Laravel/Router/DetermineLaravelControllerNameTest.php
@@ -15,6 +15,7 @@ use Psr\Log\LogLevel;
 use Scoutapm\Laravel\Router\DetermineLaravelControllerName;
 use Scoutapm\Logger\FilteredLogLevelDecorator;
 
+use function class_exists;
 use function uniqid;
 
 /** @covers \Scoutapm\Laravel\Router\DetermineLaravelControllerName */
@@ -32,6 +33,10 @@ final class DetermineLaravelControllerNameTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
+
+        if (! class_exists(Router::class)) {
+            self::markTestSkipped(Router::class . ' is not available in the current dependency tree');
+        }
 
         $this->logger = $this->createMock(LoggerInterface::class);
         $this->router = $this->createMock(Router::class);

--- a/tests/Unit/Laravel/Router/DetermineLumenControllerNameTest.php
+++ b/tests/Unit/Laravel/Router/DetermineLumenControllerNameTest.php
@@ -14,6 +14,8 @@ use Psr\Log\LogLevel;
 use Scoutapm\Laravel\Router\DetermineLumenControllerName;
 use Scoutapm\Logger\FilteredLogLevelDecorator;
 
+use function class_exists;
+
 /**
  * @covers \Scoutapm\Laravel\Router\DetermineLumenControllerName
  * @psalm-import-type LumenRouterActionShape from DetermineLumenControllerName
@@ -32,6 +34,10 @@ final class DetermineLumenControllerNameTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
+
+        if (! class_exists(Router::class)) {
+            self::markTestSkipped(Router::class . ' is not available in the current dependency tree');
+        }
 
         $this->logger = $this->createMock(LoggerInterface::class);
         $this->router = $this->createMock(Router::class);
@@ -75,7 +81,7 @@ final class DetermineLumenControllerNameTest extends TestCase
                     static function (): void {
                     },
                 ],
-                'closure_DetermineLumenControllerNameTest.php@75',
+                'closure_%s@%d',
             ],
         ];
     }
@@ -99,7 +105,7 @@ final class DetermineLumenControllerNameTest extends TestCase
                 ],
             ]);
 
-        self::assertSame(
+        self::assertStringMatchesFormat(
             self::EXPECTED_CONTROLLER_PREFIX . $expectedControllerSuffix,
             $this->determineControllerName->__invoke($request)
         );

--- a/tests/Unit/Laravel/Router/DetermineLumenControllerNameTest.php
+++ b/tests/Unit/Laravel/Router/DetermineLumenControllerNameTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scoutapm\UnitTests\Laravel\Router;
+
+use Exception;
+use Illuminate\Http\Request;
+use Laravel\Lumen\Routing\Router;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Scoutapm\Laravel\Router\DetermineLumenControllerName;
+use Scoutapm\Logger\FilteredLogLevelDecorator;
+
+/**
+ * @covers \Scoutapm\Laravel\Router\DetermineLumenControllerName
+ * @psalm-import-type LumenRouterActionShape from DetermineLumenControllerName
+ */
+final class DetermineLumenControllerNameTest extends TestCase
+{
+    private const EXPECTED_CONTROLLER_PREFIX = 'Controller/';
+
+    /** @var LoggerInterface&MockObject */
+    private $logger;
+    /** @var Router&MockObject */
+    private $router;
+    /** @var DetermineLumenControllerName */
+    private $determineControllerName;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->router = $this->createMock(Router::class);
+
+        $this->determineControllerName = new DetermineLumenControllerName(
+            new FilteredLogLevelDecorator($this->logger, LogLevel::DEBUG),
+            $this->router
+        );
+    }
+
+    /**
+     * @psalm-return array<
+     *      string,
+     *      array{
+     *          0: LumenRouterActionShape,
+     *          1: string,
+     *      }
+     * >
+     */
+    public function validRouteActionConfigurationToControllerNameProvider(): array
+    {
+        return [
+            'usesWithAs' => [
+                ['uses' => 'A@b', 'as' => 'myroute'],
+                'myroute',
+            ],
+            'usesWithoutAs' => [
+                ['uses' => 'A@b'],
+                'A@b',
+            ],
+            'callableWithAs' => [
+                [
+                    'as' => 'myroute',
+                    static function (): void {
+                    },
+                ],
+                'myroute',
+            ],
+            'callableWithoutAs' => [
+                [
+                    static function (): void {
+                    },
+                ],
+                'closure_DetermineLumenControllerNameTest.php@75',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider validRouteActionConfigurationToControllerNameProvider
+     * @psalm-param LumenRouterActionShape $actionConfiguration
+     */
+    public function testControllerNameIsReturnedWhenRouteMatches(array $actionConfiguration, string $expectedControllerSuffix): void
+    {
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => '/theurl', 'REQUEST_METHOD' => 'GET']);
+
+        $this->router
+            ->expects(self::once())
+            ->method('getRoutes')
+            ->willReturn([
+                'GET/theurl' => [
+                    'method' => 'GET',
+                    'uri' => '/theurl',
+                    'action' => $actionConfiguration,
+                ],
+            ]);
+
+        self::assertSame(
+            self::EXPECTED_CONTROLLER_PREFIX . $expectedControllerSuffix,
+            $this->determineControllerName->__invoke($request)
+        );
+    }
+
+    public function testControllerNameIsUnknownWhenMatchedRouteDoesNotFollowExpectedFormat(): void
+    {
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => '/theurl', 'REQUEST_METHOD' => 'GET']);
+
+        $this->router
+            ->expects(self::once())
+            ->method('getRoutes')
+            ->willReturn([
+                'GET/theurl' => [
+                    'method' => 'GET',
+                    'uri' => '/theurl',
+                    'action' => [],
+                ],
+            ]);
+
+        self::assertSame(
+            self::EXPECTED_CONTROLLER_PREFIX . 'unknown',
+            $this->determineControllerName->__invoke($request)
+        );
+    }
+
+    public function testControllerNameIsUnknownAndExceptionLoggedWhenRouterThrowsException(): void
+    {
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => '/theurl', 'REQUEST_METHOD' => 'GET']);
+
+        $this->router
+            ->expects(self::once())
+            ->method('getRoutes')
+            ->willThrowException(new Exception('oh no'));
+
+        $this->logger->expects(self::once())
+            ->method('log')
+            ->with(
+                LogLevel::DEBUG,
+                '[Scout] Exception obtaining name of Lumen endpoint: oh no'
+            );
+
+        self::assertSame(
+            self::EXPECTED_CONTROLLER_PREFIX . 'unknown',
+            $this->determineControllerName->__invoke($request)
+        );
+    }
+}


### PR DESCRIPTION
Fixes scoutapp/scout-apm-laravel#48

This PR adds support for Lumen, targeting `6.1.0` release of `scout-apm-php`.

 * [x] Controller & Middleware instrumentation
 * [x] Database query instrumentation
 * [x] Views instrumentation
 * [x] Job queues instrumentation
 * [x] Ensure CI matrix compatiblity
 * [x] Changelog update
 * [x] Lumen versions supported (TBD - investigation ongoing)
   * :heavy_check_mark: 5.* (5.5+)
   * :heavy_check_mark: 6.*
   * :heavy_check_mark: 7.*
   * :heavy_check_mark: 8.*
 * [x] Set up `scoutapp/scout-apm-lumen` repo to define supported Lumen versions 

![Screenshot from 2021-04-02 09-16-46](https://user-images.githubusercontent.com/496145/113408804-f2f69580-93a7-11eb-8ef9-7f04b28ee458.png)