### PR TITLE
Fix X-Request-Start header when added to server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#213](https://github.com/scoutapp/scout-apm-php/pull/213) Fix X-Request-Start header not being recognised in some situations
 
 ## 6.0.1 - 2021-03-19
 

--- a/src/Helper/FetchRequestHeaders.php
+++ b/src/Helper/FetchRequestHeaders.php
@@ -8,18 +8,23 @@ use function array_combine;
 use function array_filter;
 use function array_keys;
 use function array_map;
+use function in_array;
 use function is_string;
 use function str_replace;
-use function strpos;
 use function strtolower;
 use function substr;
 use function ucwords;
 
 use const ARRAY_FILTER_USE_BOTH;
 
+/** @internal */
 abstract class FetchRequestHeaders
 {
-    /** @return array<string, string> */
+    /**
+     * @internal
+     *
+     * @return array<string, string>
+     */
     public static function fromServerGlobal(): array
     {
         return self::fromArray($_SERVER);
@@ -37,7 +42,11 @@ abstract class FetchRequestHeaders
         return array_combine(
             array_map(
                 static function (string $key): string {
-                    return ucwords(str_replace('_', '-', strtolower(substr($key, 5))), '-');
+                    if (in_array(strtolower(substr($key, 0, 5)), ['http_', 'http-'], true)) {
+                        $key = substr($key, 5);
+                    }
+
+                    return ucwords(str_replace('_', '-', strtolower($key)), '-');
                 },
                 array_keys($qualifyingServerKeys)
             ),
@@ -63,8 +72,7 @@ abstract class FetchRequestHeaders
              */
             static function ($value, $key): bool {
                 return is_string($key)
-                    && $value !== ''
-                    && strpos($key, 'HTTP_') === 0;
+                    && $value !== '';
             },
             ARRAY_FILTER_USE_BOTH
         );

--- a/tests/Unit/Events/Request/RequestTest.php
+++ b/tests/Unit/Events/Request/RequestTest.php
@@ -203,6 +203,14 @@ final class RequestTest extends TestCase
                 'headerName' => 'HTTP_X_REQUEST_START',
                 'headerValue' => sprintf('%d', (self::FIXED_POINT_UNIX_EPOCH_SECONDS * 1000000000) + 2000000),
             ],
+            'requestStartWhenNotPrefixedWithHttp' => [
+                'headerName' => 'X-Request-Start',
+                'headerValue' => sprintf('%d', (self::FIXED_POINT_UNIX_EPOCH_SECONDS * 1000) + 2),
+            ],
+            'requestStartWhenNotPrefixedWithHttpLowercase' => [
+                'headerName' => 'x-request-start',
+                'headerValue' => sprintf('%d', (self::FIXED_POINT_UNIX_EPOCH_SECONDS * 1000) + 2),
+            ],
         ];
     }
 

--- a/tests/Unit/Helper/FetchRequestHeadersTest.php
+++ b/tests/Unit/Helper/FetchRequestHeadersTest.php
@@ -30,6 +30,10 @@ final class FetchRequestHeadersTest extends TestCase
 
         self::assertEquals(
             [
+                'Script-Name' => $oldServer['SCRIPT_NAME'],
+                'Request-Time' => $oldServer['REQUEST_TIME'],
+                'Document-Root' => '/path/to/public',
+                'Remote-Addr' => '127.0.0.1',
                 'Host' => 'scout-apm-test',
                 'User-Agent' => 'Scout APM test',
                 'Cookie' => 'cookie_a=null; cookie_b=null',


### PR DESCRIPTION
Fixes #212 

Previously only `$_SERVER` values prefixed with `HTTP_` (i.e. HTTP headers) were returned; I updated this as in some cases (e.g. with nginx configuration) the `X-Request-Start` header value may be set directly into `$_SERVER`, rather than being prefixed (such as how Apache does by default). This makes the header checking more flexible and less fussy to configure.