### PR TITLE
Ensure uri_filtered_params are coerced from JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file, in reverse 
 - [#229](https://github.com/scoutapp/scout-apm-php/pull/229) Updated `scoutapm.stub.php` stub to match latest extension version
 - [#227](https://github.com/scoutapp/scout-apm-php/pull/227) Fixed "double logging" of SQL queries with new "leafNode" flag on spans
 - [#231](https://github.com/scoutapp/scout-apm-php/pull/231) Fixed how TwigMethods traits are included to work with Composer optimised autoloader properly
+- [#232](https://github.com/scoutapp/scout-apm-php/pull/232) Ensure `uri_filtered_params` are coerced from JSON
 
 ## 6.3.0 - 2021-06-17
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -55,6 +55,7 @@ class Config
             ConfigKey::IGNORED_ENDPOINTS => new CoerceJson(),
             ConfigKey::DISABLED_INSTRUMENTS => new CoerceJson(),
             ConfigKey::LOG_PAYLOAD_CONTENT => new CoerceBoolean(),
+            ConfigKey::URI_FILTERED_PARAMETERS => new CoerceJson(),
         ];
     }
 

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -67,6 +67,17 @@ final class ConfigTest extends TestCase
         self::assertSame([], (new Config())->get(ConfigKey::IGNORED_ENDPOINTS));
     }
 
+    public function testFilteredParamsAreParsedToArrayFromJson(): void
+    {
+        $config = new Config();
+
+        putenv('SCOUT_URI_FILTERED_PARAMS=["a","b"]');
+
+        self::assertEquals(['a', 'b'], $config->get(ConfigKey::URI_FILTERED_PARAMETERS));
+
+        putenv('SCOUT_URI_FILTERED_PARAMS');
+    }
+
     public function testAsArray(): void
     {
         $configArray = Config::fromArray([


### PR DESCRIPTION
Mentioned in https://github.com/scoutapp/scout-apm-php/pull/228#issuecomment-878425187 - reminded me that the new `uri_filtered_params` config should be converted from JSON string, if it is not already.