### PR TITLE
Allow core-agent to fully start in GH Actions

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -100,7 +100,11 @@ jobs:
           cd test-app
           cat .env
           php artisan serve &
+          # Give Laravel a chance to start...
           sleep 2
+          # Very occasionally in GH Actions, core-agent didn't quite start in time - so load the page twice
+          wget -O /dev/null http://localhost:8000
+          sleep 1
           wget http://localhost:8000
           cat index.html
           ps -ax

--- a/.github/workflows/lumen.yml
+++ b/.github/workflows/lumen.yml
@@ -106,7 +106,11 @@ jobs:
           cd test-app
           cat .env
           LOG_CHANNEL=single php -S localhost:8000 -t public/ &
+          # Give Lumen a chance to start...
           sleep 2
+          # Very occasionally in GH Actions, core-agent didn't quite start in time - so load the page twice
+          wget -O /dev/null http://localhost:8000
+          sleep 1
           wget http://localhost:8000
           cat index.html
           ps -ax


### PR DESCRIPTION
Seems there's sometimes a race condition in which `core-agent` does not fully start up by the time we try the `wget localhost` and check the logs in the E2E tests. This adds a primitive workaround - load the page once to get `core-agent` started, sleep, then run it again for the "actual" check. It's not pretty, but if we still get issues after then there may be something else wrong.