### PR TITLE
Prevent recording of child spans of a 'leaf' span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 - [#236](https://github.com/scoutapp/scout-apm-php/pull/236) Replace `doctrine/cache` with `cache/array-adapter` in tests
   - Note - this change only affects our internal tests, the `Agent` still depends on *any* PSR-16 compatible cache (including `doctrine/cache`)
+- [#237](https://github.com/scoutapp/scout-apm-php/pull/237) Made 'leaf span' recording more efficient so child spans are not recorded at all
 
 ### Deprecated
 

--- a/src/Events/Span/Span.php
+++ b/src/Events/Span/Span.php
@@ -85,6 +85,11 @@ class Span implements CommandWithParent, CommandWithChildren
         return $this->parent;
     }
 
+    public function isLeaf(): bool
+    {
+        return $this->leafSpan;
+    }
+
     /**
      * Do not call this directly - use Request#stopSpan() or Agent#stopSpan() to correctly handle bookkeeping
      *
@@ -186,10 +191,6 @@ class Span implements CommandWithParent, CommandWithChildren
         ];
 
         foreach ($this->children as $child) {
-            if ($this->leafSpan && $child instanceof Span) {
-                continue;
-            }
-
             foreach ($child->jsonSerialize() as $value) {
                 $commands[] = $value;
             }

--- a/tests/Unit/Events/Span/SpanTest.php
+++ b/tests/Unit/Events/Span/SpanTest.php
@@ -33,6 +33,12 @@ final class SpanTest extends TestCase
         self::assertNull($span->getStopTime());
     }
 
+    public function testThatASpanKnowsItIsALeafNode(): void
+    {
+        $span = new Span($this->mockParent, 'name', RequestId::new(), null, true);
+        self::assertTrue($span->isLeaf());
+    }
+
     /** @throws Exception */
     public function testCanBeStopped(): void
     {

--- a/tests/Unit/TestHelper.php
+++ b/tests/Unit/TestHelper.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scoutapm\UnitTests;
+
+use InvalidArgumentException;
+use ReflectionException;
+use ReflectionProperty;
+use Scoutapm\Connector\Command;
+use Scoutapm\Connector\CommandWithChildren;
+use Webmozart\Assert\Assert;
+
+use function count;
+use function reset;
+
+final class TestHelper
+{
+    /**
+     * @return Command[]
+     *
+     * @throws InvalidArgumentException|ReflectionException
+     */
+    public static function childrenForCommand(CommandWithChildren $commandWithChildren): array
+    {
+        $childrenProperty = new ReflectionProperty($commandWithChildren, 'children');
+        $childrenProperty->setAccessible(true);
+        $children = $childrenProperty->getValue($commandWithChildren);
+
+        Assert::isArray($children);
+        Assert::allIsInstanceOf($children, Command::class);
+
+        return $children;
+    }
+
+    public static function firstChildForCommand(CommandWithChildren $commandWithChildren): Command
+    {
+        $children = self::childrenForCommand($commandWithChildren);
+
+        Assert::greaterThanEq(count($children), 1);
+
+        return reset($children);
+    }
+}


### PR DESCRIPTION
The initial 'leaf span' implementation involved just preventing serialisation of anything below a leaf node. This new approach will prevent recording any child spans belonging to a leaf span.﻿
