### PR TITLE
Update CI workflows to use pull_request_target instead of pull_request

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -3,7 +3,7 @@ name: Laravel Build
 on:
   push:
     branches: [ master ]
-  pull_request:
+  pull_request_target:
     branches: [ master ]
   schedule:
     - cron: '37 9 1 * *'

--- a/.github/workflows/lumen.yml
+++ b/.github/workflows/lumen.yml
@@ -3,7 +3,7 @@ name: Lumen Build
 on:
   push:
     branches: [ master ]
-  pull_request:
+  pull_request_target:
     branches: [ master ]
   schedule:
     - cron: '37 9 1 * *'

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -3,7 +3,7 @@ name: Quality Checks
 on:
   push:
     branches: [ master ]
-  pull_request:
+  pull_request_target:
     branches: [ master ]
   schedule:
     - cron: '37 9 1 * *'

--- a/.github/workflows/symfony.yml
+++ b/.github/workflows/symfony.yml
@@ -3,7 +3,7 @@ name: Symfony Build
 on:
   push:
     branches: [ master ]
-  pull_request:
+  pull_request_target:
     branches: [ master ]
   schedule:
     - cron: '37 9 1 * *'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: Main Tests
 on:
   push:
     branches: [ master ]
-  pull_request:
+  pull_request_target:
     branches: [ master ]
   schedule:
     - cron: '37 9 1 * *'


### PR DESCRIPTION
Fixes #218

https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/

It appears that in forked repos, the `pull_request` event does not allow access to secrets, for security, and therefore any CI builds from forks will fail.

The blog post above suggests that using `pull_request_target` runs the same build but in a safer context, meaning secrets can be accessed. This should fix the issue of contributed PRs failing.