### PR TITLE
Fix CI failures

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -56,6 +56,7 @@ jobs:
       - name: "Install scoutapm extension"
         if: ${{ matrix.scout-ext == 'with-scout-ext' }}
         run: |
+          sudo apt --fix-broken install
           sudo apt-get install -y libcurl4-openssl-dev
           sudo mkdir -p /tmp/pear/temp
           sudo pecl update-channels


### PR DESCRIPTION
Fixes [this issue](https://github.com/scoutapp/scout-apm-php/runs/4850034468?check_suite_focus=true):

```
Run sudo apt-get install -y libcurl4-openssl-dev
Reading package lists...
Building dependency tree...
Reading state information...
You might want to run 'apt --fix-broken install' to correct these.
The following packages have unmet dependencies:
 libpcre3-dev : Depends: libpcre3 (= 2:8.44-2+ubuntu20.04.1+deb.sury.org+1) but 2:8.39-12build1 is to be installed
 libpcrecpp0v5 : Depends: libpcre3 (>= 2:8.41) but 2:8.39-12build1 is to be installed
 php7.1-cgi : Depends: libpcre3 (>= 2:8.41) but 2:8.39-12build1 is to be installed
 php7.1-cli : Depends: libpcre3 (>= 2:8.41) but 2:8.39-12build1 is to be installed
 php7.1-fpm : Depends: libpcre3 (>= 2:8.41) but 2:8.39-12build1 is to be installed
 php7.1-phpdbg : Depends: libpcre3 (>= 2:8.41) but 2:8.39-12build1 is to be installed
E: Unmet dependencies. Try 'apt --fix-broken install' with no packages (or specify a solution).
Error: Process completed with exit code 100.
```