### PR TITLE
Prevent the same exception from being sent to Scout multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 8.0.1 - 2022-03-23
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- [#261](https://github.com/scoutapp/scout-apm-php/pull/261) Prevent the same exception from being sent to Scout multiple times
+
 ## 8.0.0 - 2022-03-08
 
 ### Added

--- a/tests/Unit/Errors/ScoutErrorHandlingTest.php
+++ b/tests/Unit/Errors/ScoutErrorHandlingTest.php
@@ -175,10 +175,26 @@ final class ScoutErrorHandlingTest extends TestCase
 
         $this->reportingClient
             ->expects(self::never())
-            ->method('sendErrorToScout')
-            ->with(self::isInstanceOf(ErrorEvent::class));
+            ->method('sendErrorToScout');
 
         $handling->recordThrowable(new RuntimeException());
+
+        $handling->sendCollectedErrors();
+    }
+
+    public function testExactlyTheSameExceptionIsNotSentTwice(): void
+    {
+        $handling = $this->errorHandlingFromConfig(Config::fromArray([Config\ConfigKey::ERRORS_ENABLED => true]));
+
+        $this->reportingClient
+            ->expects(self::once())
+            ->method('sendErrorToScout')
+            ->with(self::containsOnlyInstancesOf(ErrorEvent::class));
+
+        $exceptionInstance = new RuntimeException();
+
+        $handling->recordThrowable($exceptionInstance);
+        $handling->recordThrowable($exceptionInstance);
 
         $handling->sendCollectedErrors();
     }


### PR DESCRIPTION
Fixes a bug where the same exception could be sent twice if an exception is not handled by the application - quite an edge case as the majority of applications would already have error handlers defined.