### PR TITLE
Remove automated changelog update step from automated releases

### DIFF
--- a/.github/workflows/release-on-milestone-closed-triggering-release-event.yml
+++ b/.github/workflows/release-on-milestone-closed-triggering-release-event.yml
@@ -50,16 +50,6 @@ jobs:
           "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
 
-      - name: "Bump Changelog Version On Originating Release Branch"
-        uses: "laminas/automatic-releases@v1"
-        with:
-          command-name: "laminas:automatic-releases:bump-changelog"
-        env:
-          "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN }}
-          "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
-          "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
-          "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
-
       - name: "Create new milestones"
         uses: "laminas/automatic-releases@v1"
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,28 +7,6 @@ All notable changes to this project will be documented in this file, in reverse 
 Please see [https://github.com/scoutapp/scout-apm-php/releases](https://github.com/scoutapp/scout-apm-php/releases) for
 release 8.1.0 onwards.
 
-## 8.2.0 - TBD
-
-### Added
-
-- Nothing.
-
-### Changed
-
-- Nothing.
-
-### Deprecated
-
-- Nothing.
-
-### Removed
-
-- Nothing.
-
-### Fixed
-
-- Nothing.
-
 ## 8.0.1 - 2022-03-23
 
 ### Added


### PR DESCRIPTION
Remove automated changelog update step since release notes are sufficient