### PR TITLE
Update CI workflows to use pull_request_target instead of pull_request

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-  pull_request:
+  pull_request_target:
   schedule:
     - cron: '37 9 1 * *'
 


### PR DESCRIPTION
Fixes #218

https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/

It appears that in forked repos, the `pull_request` event does not allow access to secrets, for security, and therefore any CI builds from forks will fail.

The blog post above suggests that using `pull_request_target` runs the same build but in a safer context, meaning secrets can be accessed. This should fix the issue of contributed PRs failing.