### PR TITLE
Fix compatibility with spatie/laravel-ignition

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -392,6 +392,9 @@ jobs:
         run: "composer remove --dev symfony/* laravel/* --no-update --no-interaction"
       - name: "Require framework ${{ matrix.laravel-version}}"
         run: "composer require laravel/framework:${{ matrix.laravel-version}} --no-update --no-interaction --prefer-dist --prefer-stable"
+      - name: "Install spatie/laravel-ignition (if available)"
+        if: ${{ (matrix.php-version == '8.0' || matrix.php-version == '8.1') && (matrix.laravel-version == '8.*' || matrix.laravel-version == '9.*') }}
+        run: "composer require --dev spatie/laravel-ignition --no-update --no-interaction"
       - name: "Replace guzzlehttp/guzzle with php-http/guzzle6-adapter for PHP 7.1"
         if: ${{ matrix.php-version == '7.1' }}
         run: |

--- a/known-issues.xml
+++ b/known-issues.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.22.0@fc2c6ab4d5fa5d644d8617089f012f3bb84b8703">
+<files psalm-version="4.24.0@06dd975cb55d36af80f242561738f16c5f58264f">
   <file src="src/Agent.php">
-    <MixedArgument occurrences="10">
+    <MixedArgument occurrences="9">
       <code>$config-&gt;get(ConfigKey::MONITORING_ENABLED)</code>
       <code>$configuration-&gt;get(ConfigKey::IGNORED_ENDPOINTS)</code>
-      <code>$this-&gt;config-&gt;get(ConfigKey::APPLICATION_NAME)</code>
       <code>$this-&gt;config-&gt;get(ConfigKey::APPLICATION_NAME)</code>
       <code>$this-&gt;config-&gt;get(ConfigKey::CORE_AGENT_CONFIG_FILE)</code>
       <code>$this-&gt;config-&gt;get(ConfigKey::CORE_AGENT_DOWNLOAD_URL)</code>
@@ -27,11 +26,6 @@
     <MixedReturnStatement occurrences="1">
       <code>$this-&gt;config-&gt;get(ConfigKey::MONITORING_ENABLED)</code>
     </MixedReturnStatement>
-  </file>
-  <file src="src/Cache/DevNullCache.php">
-    <MixedArgumentTypeCoercion occurrences="1">
-      <code>$keysAsArray</code>
-    </MixedArgumentTypeCoercion>
   </file>
   <file src="src/Config.php">
     <MixedArgumentTypeCoercion occurrences="1">
@@ -335,6 +329,19 @@
     </MixedAssignment>
   </file>
   <file src="tests/Unit/Laravel/View/Engine/ScoutViewEngineDecoratorTest.php">
+    <MixedArgument occurrences="1">
+      <code>BladeSourceMapCompiler::class</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$vem</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>map</code>
+    </MixedMethodCall>
+    <UndefinedClass occurrences="2">
+      <code>BladeSourceMapCompiler</code>
+      <code>ViewException</code>
+    </UndefinedClass>
     <UnusedClosureParam occurrences="4">
       <code>$name</code>
       <code>$name</code>

--- a/src/Laravel/View/Engine/ScoutViewEngineDecorator.php
+++ b/src/Laravel/View/Engine/ScoutViewEngineDecorator.php
@@ -17,8 +17,15 @@ final class ScoutViewEngineDecorator implements Engine
 {
     public const VIEW_FACTORY_SHARED_KEY = '__scout_apm_view_name';
 
-    /** @var Engine */
-    private $realEngine;
+    /**
+     * Note: property MUST be called `$engine` as package `spatie/laravel-ignition` makes assumptions about how
+     * implementors of {@see Engine} structure their classes.
+     *
+     * @link https://github.com/spatie/laravel-ignition/blob/d53075177ee0c710fbf588b8569f50435e1da054/src/Views/ViewExceptionMapper.php#L124-L130
+     *
+     * @var Engine
+     */
+    private $engine;
 
     /** @var ScoutApmAgent */
     private $agent;
@@ -26,9 +33,9 @@ final class ScoutViewEngineDecorator implements Engine
     /** @var Factory */
     private $viewFactory;
 
-    public function __construct(Engine $realEngine, ScoutApmAgent $agent, Factory $viewFactory)
+    public function __construct(Engine $engine, ScoutApmAgent $agent, Factory $viewFactory)
     {
-        $this->realEngine  = $realEngine;
+        $this->engine      = $engine;
         $this->agent       = $agent;
         $this->viewFactory = $viewFactory;
     }
@@ -42,7 +49,7 @@ final class ScoutViewEngineDecorator implements Engine
             'View',
             (string) $this->viewFactory->shared(self::VIEW_FACTORY_SHARED_KEY, 'unknown'),
             function () use ($path, $data) {
-                return $this->realEngine->get($path, $data);
+                return $this->engine->get($path, $data);
             }
         );
     }
@@ -55,9 +62,9 @@ final class ScoutViewEngineDecorator implements Engine
      */
     public function getCompiler(): CompilerInterface
     {
-        assert(method_exists($this->realEngine, 'getCompiler'));
+        assert(method_exists($this->engine, 'getCompiler'));
         /** @psalm-suppress UndefinedInterfaceMethod */
-        $compiler = $this->realEngine->getCompiler();
+        $compiler = $this->engine->getCompiler();
         assert($compiler instanceof CompilerInterface);
 
         return $compiler;


### PR DESCRIPTION
Renames `realEngine` to `engine` as package `spatie/laravel-ignition` makes assumptions about how implementors of {@see Engine} structure their classes.

https://github.com/spatie/laravel-ignition/blob/d53075177ee0c710fbf588b8569f50435e1da054/src/Views/ViewExceptionMapper.php#L124-L130

Fixes #273 