### PR TITLE
Add laravel artisan command for core-agent

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -474,6 +474,81 @@ jobs:
           echo "Checking for Error Reporting"
           grep -q "local.DEBUG: \[Scout\] Sent 1 error event to Scout Error Reporting" storage/logs/laravel.log
 
+  artisan-test:
+    needs: [ check_secrets, laravel-unit ]
+    if: needs.check_secrets.outputs.has_scout_apm_key_secret == 'true'
+    name: "Artisan Test"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        extensions: ["scoutapm", ""]
+        laravel-version:
+          - "5.5.*"
+          - "6.*"
+          - "7.*"
+          - "8.*"
+          - "9.*"
+        php-version:
+          - "7.2"
+          - "7.3"
+          - "7.4"
+          - "8.0"
+          - "8.1"
+        exclude:
+          # See - https://laravel.com/docs/8.x/releases#support-policy
+          # See - https://github.com/laravel/framework/issues/40339
+          # Laravel 5.5 supports PHP 7.1 - 7.4
+          - {laravel-version: "5.5.*", php-version: "8.0"} # Laravel 5.5.* does not support PHP 8.0+
+          - {laravel-version: "5.5.*", php-version: "8.1"} # Laravel 5.5.* does not support PHP 8.0+
+          # Laravel 6 supports PHP 7.2 - 8.0
+          - {laravel-version: "6.*", php-version: "8.1"} # Laravel 6 does not support PHP 8.1+
+          # Laravel 7 supports PHP 7.2 - 8.0
+          - {laravel-version: "7.*", php-version: "8.1"} # Laravel 7 does not support PHP 8.1+
+          # Laravel 8 supports PHP 7.3 - 8.1
+          - {laravel-version: "8.*", php-version: "7.2"} # Laravel 8 requires 7.3+
+          # Laravel 9 supports PHP 7.3 - 8.1
+          - {laravel-version: "9.*", php-version: "7.2"} # Laravel 9 requires 8.0+
+          - {laravel-version: "9.*", php-version: "7.3"} # Laravel 9 requires 8.0+
+          - {laravel-version: "9.*", php-version: "7.4"} # Laravel 9 requires 8.0+
+    env:
+      SCOUT_APM_KEY: ${{ secrets.SCOUT_APM_KEY }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: scout-apm-php
+      - name: "Install PHP"
+        uses: shivammathur/setup-php@v2
+        with:
+          coverage: "none"
+          php-version: "${{ matrix.php-version }}"
+          tools: pecl, composer:v2.3
+          extensions: ${{ matrix.extensions }}
+        env:
+          fail-fast: true
+      - name: "Composer allow-plugins to allow Laravel to actually install"
+        run: composer config --global allow-plugins true
+      - name: "Install Laravel quickstart project"
+        run: "composer create-project laravel/laravel:${{ matrix.laravel-version}} test-app --prefer-dist"
+      - name: "Add scout-apm-php as a repository"
+        run: cd test-app && composer config repositories.scout path ../scout-apm-php
+      - name: "Require scout-apm-php current checkout"
+        run: cd test-app && composer require scoutapp/scout-apm-php:*@dev guzzlehttp/guzzle composer/package-versions-deprecated
+      - name: "Publish the provider"
+        run: cd test-app && php artisan vendor:publish --provider="Scoutapm\Laravel\Providers\ScoutApmServiceProvider"
+      - name: "Configure Scout"
+        run: cd test-app && echo -e "\nSCOUT_KEY=\"\${SCOUT_APM_KEY}\"\nSCOUT_NAME=\"My Laravel App\"\nSCOUT_MONITOR=true\nSCOUT_LOG_LEVEL=\"debug\"\nSCOUT_ERRORS_ENABLED=true" >> .env
+      - name: "Run core agent"
+        run: |
+          cd test-app
+          cat .env
+          php artisan scoutapm:core-agent --download --launch
+      - name: "Check core agent is running"
+        run: |
+          sleep 2
+          ps ax | grep core-agent
+          pgrep core-agent
+
 ###############################################################################
 #################################### LUMEN ####################################
 ###############################################################################

--- a/known-issues.xml
+++ b/known-issues.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.22.0@fc2c6ab4d5fa5d644d8617089f012f3bb84b8703">
+<files psalm-version="4.24.0@06dd975cb55d36af80f242561738f16c5f58264f">
   <file src="src/Agent.php">
-    <MixedArgument occurrences="9">
-      <code>$config-&gt;get(ConfigKey::MONITORING_ENABLED)</code>
+    <DocblockTypeContradiction occurrences="2">
+      <code>! is_array($disabledInstruments)</code>
+    </DocblockTypeContradiction>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$configuration-&gt;get(ConfigKey::IGNORED_ENDPOINTS)</code>
+    </MixedArgumentTypeCoercion>
+    <PossiblyNullArgument occurrences="2">
       <code>$configuration-&gt;get(ConfigKey::IGNORED_ENDPOINTS)</code>
       <code>$this-&gt;config-&gt;get(ConfigKey::APPLICATION_NAME)</code>
-      <code>$this-&gt;config-&gt;get(ConfigKey::CORE_AGENT_CONFIG_FILE)</code>
-      <code>$this-&gt;config-&gt;get(ConfigKey::CORE_AGENT_DOWNLOAD_URL)</code>
-      <code>$this-&gt;config-&gt;get(ConfigKey::CORE_AGENT_FULL_NAME)</code>
-      <code>$this-&gt;config-&gt;get(ConfigKey::CORE_AGENT_LOG_FILE)</code>
-      <code>$this-&gt;config-&gt;get(ConfigKey::CORE_AGENT_LOG_LEVEL)</code>
-      <code>$this-&gt;config-&gt;get(ConfigKey::CORE_AGENT_PERMISSIONS)</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="2">
-      <code>$disabledInstruments</code>
-      <code>$shouldLogContent</code>
-    </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>bool</code>
-    </MixedInferredReturnType>
-    <MixedOperand occurrences="2">
-      <code>$this-&gt;config-&gt;get(ConfigKey::CORE_AGENT_DIRECTORY)</code>
-      <code>$this-&gt;config-&gt;get(ConfigKey::CORE_AGENT_FULL_NAME)</code>
-    </MixedOperand>
-    <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;config-&gt;get(ConfigKey::MONITORING_ENABLED)</code>
-    </MixedReturnStatement>
+    </PossiblyNullArgument>
+    <RedundantCastGivenDocblockType occurrences="2">
+      <code>(string) $config-&gt;get(ConfigKey::LOG_LEVEL)</code>
+      <code>(string) $this-&gt;config-&gt;get(ConfigKey::API_VERSION)</code>
+    </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Config.php">
     <MixedArgumentTypeCoercion occurrences="1">
@@ -36,26 +25,15 @@
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
+    <MixedInferredReturnType occurrences="1"/>
+    <MixedReturnStatement occurrences="1">
+      <code>$value ?? null</code>
+    </MixedReturnStatement>
   </file>
   <file src="src/Config/IgnoredEndpoints.php">
     <MixedAssignment occurrences="1">
       <code>$ignore</code>
     </MixedAssignment>
-  </file>
-  <file src="src/Config/Source/DerivedSource.php">
-    <MixedAssignment occurrences="2">
-      <code>$triple</code>
-      <code>$version</code>
-    </MixedAssignment>
-    <MixedOperand occurrences="2">
-      <code>$triple</code>
-      <code>$version</code>
-    </MixedOperand>
-  </file>
-  <file src="src/Connector/ConnectionAddress.php">
-    <MixedArgument occurrences="1">
-      <code>$config-&gt;get(ConfigKey::CORE_AGENT_SOCKET_PATH)</code>
-    </MixedArgument>
   </file>
   <file src="src/Connector/SocketConnector.php">
     <MixedArgument occurrences="1">
@@ -87,16 +65,20 @@
       <code>$this-&gt;sha256</code>
     </MixedAssignment>
   </file>
-  <file src="src/Errors/ErrorEvent.php">
-    <MixedArgumentTypeCoercion occurrences="1"/>
+  <file src="src/Errors/ErrorHandlingDiscoveryFactory.php">
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(bool) $config-&gt;get(Config\ConfigKey::ERRORS_ENABLED)</code>
+    </RedundantCastGivenDocblockType>
   </file>
-  <file src="src/Events/Metadata.php">
-    <MixedAssignment occurrences="1">
-      <code>$scmSubdirectoryConfiguration</code>
-    </MixedAssignment>
-    <MixedReturnTypeCoercion occurrences="2">
-      <code>array&lt;string, (string|VersionList|null)&gt;</code>
-    </MixedReturnTypeCoercion>
+  <file src="src/Errors/ScoutClient/HttpErrorReportingClient.php">
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(string) $this-&gt;config-&gt;get(ConfigKey::ERRORS_HOST)</code>
+    </RedundantCastGivenDocblockType>
+  </file>
+  <file src="src/Errors/ScoutErrorHandling.php">
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(bool) $this-&gt;config-&gt;get(Config\ConfigKey::ERRORS_ENABLED)</code>
+    </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Events/Request/Request.php">
     <MixedAssignment occurrences="2">
@@ -138,13 +120,9 @@
     <MixedArgument occurrences="1">
       <code>$app-&gt;make(self::CONFIG_SERVICE_KEY)-&gt;get(ConfigKey::LOG_LEVEL)</code>
     </MixedArgument>
-    <UndefinedClass occurrences="2">
+    <UndefinedClass occurrences="1">
       <code>$app-&gt;make(self::CONFIG_SERVICE_KEY)</code>
-      <code>Connection</code>
     </UndefinedClass>
-    <UndefinedDocblockClass occurrences="1">
-      <code>$application-&gt;make('db')-&gt;connection()</code>
-    </UndefinedDocblockClass>
     <UnusedClosureParam occurrences="1">
       <code>$event</code>
     </UnusedClosureParam>
@@ -176,21 +154,11 @@
       <code>$treeBuilder-&gt;root(self::ROOT_NODE_NAME)</code>
     </MixedReturnStatement>
   </file>
-  <file src="src/ScoutApmBundle/DependencyInjection/ScoutApmExtension.php">
-    <ReservedWord occurrences="1">
-      <code>$loader-&gt;load('scoutapm.xml')</code>
-    </ReservedWord>
-  </file>
   <file src="src/ScoutApmBundle/Twig/TwigDecorator.php">
     <MixedInferredReturnType occurrences="1">
       <code>string</code>
     </MixedInferredReturnType>
     <MixedReturnStatement occurrences="1"/>
-  </file>
-  <file src="tests/Integration/AgentTest.php">
-    <ReservedWord occurrences="1">
-      <code>(new PhpExecutableFinder())-&gt;find()</code>
-    </ReservedWord>
   </file>
   <file src="tests/Integration/CheckScoutApmKeyListener.php">
     <DeprecatedInterface occurrences="1">
@@ -212,70 +180,6 @@
     </MixedReturnStatement>
   </file>
   <file src="tests/Unit/AgentTest.php">
-    <DeprecatedClass occurrences="30">
-      <code>self::at(0)</code>
-      <code>self::at(0)</code>
-      <code>self::at(1)</code>
-      <code>self::at(1)</code>
-      <code>self::at(1)</code>
-      <code>self::at(1)</code>
-      <code>self::at(1)</code>
-      <code>self::at(1)</code>
-      <code>self::at(2)</code>
-      <code>self::at(2)</code>
-      <code>self::at(2)</code>
-      <code>self::at(2)</code>
-      <code>self::at(2)</code>
-      <code>self::at(2)</code>
-      <code>self::at(2)</code>
-      <code>self::at(2)</code>
-      <code>self::at(3)</code>
-      <code>self::at(3)</code>
-      <code>self::at(3)</code>
-      <code>self::at(3)</code>
-      <code>self::at(3)</code>
-      <code>self::at(3)</code>
-      <code>self::at(3)</code>
-      <code>self::at(3)</code>
-      <code>self::at(4)</code>
-      <code>self::at(4)</code>
-      <code>self::at(4)</code>
-      <code>self::at(5)</code>
-      <code>self::at(5)</code>
-      <code>self::at(6)</code>
-    </DeprecatedClass>
-    <DeprecatedMethod occurrences="30">
-      <code>self::at(0)</code>
-      <code>self::at(0)</code>
-      <code>self::at(1)</code>
-      <code>self::at(1)</code>
-      <code>self::at(1)</code>
-      <code>self::at(1)</code>
-      <code>self::at(1)</code>
-      <code>self::at(1)</code>
-      <code>self::at(2)</code>
-      <code>self::at(2)</code>
-      <code>self::at(2)</code>
-      <code>self::at(2)</code>
-      <code>self::at(2)</code>
-      <code>self::at(2)</code>
-      <code>self::at(2)</code>
-      <code>self::at(2)</code>
-      <code>self::at(3)</code>
-      <code>self::at(3)</code>
-      <code>self::at(3)</code>
-      <code>self::at(3)</code>
-      <code>self::at(3)</code>
-      <code>self::at(3)</code>
-      <code>self::at(3)</code>
-      <code>self::at(3)</code>
-      <code>self::at(4)</code>
-      <code>self::at(4)</code>
-      <code>self::at(4)</code>
-      <code>self::at(5)</code>
-      <code>self::at(5)</code>
-      <code>self::at(6)</code>
-    </DeprecatedMethod>
     <MixedArgument occurrences="5">
       <code>$commands[(self::EXPECTED_SPAN_LIMIT * 2) + 1]</code>
       <code>$commands[(self::EXPECTED_SPAN_LIMIT * 2) + 2]</code>
@@ -366,26 +270,6 @@
       <code>$block</code>
     </UnusedVariable>
   </file>
-  <file src="tests/Unit/Helper/TimerTest.php">
-    <DeprecatedMethod occurrences="2">
-      <code>self::assertRegExp(self::DATE_FORMAT_VALIDATION_REGEX, (string) $timer-&gt;getStart())</code>
-      <code>self::assertRegExp(self::DATE_FORMAT_VALIDATION_REGEX, (string) $timer-&gt;getStop())</code>
-    </DeprecatedMethod>
-  </file>
-  <file src="tests/Unit/Laravel/Database/QueryListenerTest.php">
-    <InvalidArgument occurrences="2">
-      <code>$this-&gt;createMock(Connection::class)</code>
-      <code>$this-&gt;createMock(Connection::class)</code>
-    </InvalidArgument>
-    <MixedArgument occurrences="2">
-      <code>Connection::class</code>
-      <code>Connection::class</code>
-    </MixedArgument>
-    <UndefinedClass occurrences="2">
-      <code>Connection</code>
-      <code>Connection</code>
-    </UndefinedClass>
-  </file>
   <file src="tests/Unit/Laravel/Facades/ScoutApmTest.php">
     <PossiblyInvalidArgument occurrences="1">
       <code>testFacadeProxiesMethodsToRealAgent</code>
@@ -408,37 +292,24 @@
     <InvalidArrayOffset occurrences="1">
       <code>$commands[1]['StartSpan']</code>
     </InvalidArrayOffset>
-    <InvalidPropertyAssignmentValue occurrences="1">
-      <code>$this-&gt;createMock(Connection::class)</code>
-    </InvalidPropertyAssignmentValue>
-    <MixedArgument occurrences="2">
+    <MixedArgument occurrences="1">
       <code>$commands[1]['StartSpan']</code>
-      <code>Connection::class</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="2">
       <code>$commands[1]['StartSpan']['operation']</code>
       <code>json_decode(json_encode($metadata), true)['ApplicationEvent']</code>
     </MixedArrayAccess>
-    <MixedMethodCall occurrences="2">
-      <code>method</code>
-      <code>with</code>
-    </MixedMethodCall>
     <PossiblyInvalidArgument occurrences="1">
       <code>$this-&gt;application</code>
     </PossiblyInvalidArgument>
-    <UndefinedClass occurrences="7">
+    <UndefinedClass occurrences="6">
       <code>$events</code>
       <code>$events</code>
       <code>$events</code>
       <code>$events</code>
       <code>$events</code>
       <code>$events</code>
-      <code>Connection</code>
     </UndefinedClass>
-    <UndefinedDocblockClass occurrences="2">
-      <code>$this-&gt;connection</code>
-      <code>Connection&amp;MockObject</code>
-    </UndefinedDocblockClass>
     <UnusedClosureParam occurrences="1">
       <code>$whichViews</code>
     </UnusedClosureParam>
@@ -487,18 +358,8 @@
       <code>$agentConfigurationArgument</code>
       <code>$agentConfigurationArgument</code>
     </MixedAssignment>
-    <ReservedWord occurrences="2">
-      <code>$agentDefinition-&gt;getArgument('$agentConfiguration')</code>
-      <code>$builder-&gt;getDefinition(ScoutApmAgent::class)-&gt;getArgument('$agentConfiguration')</code>
-    </ReservedWord>
   </file>
   <file src="tests/Unit/ScoutApmBundle/ScoutApmAgentFactoryTest.php">
-    <DeprecatedClass occurrences="1">
-      <code>self::at(3)</code>
-    </DeprecatedClass>
-    <DeprecatedMethod occurrences="1">
-      <code>self::at(3)</code>
-    </DeprecatedMethod>
     <MixedArgument occurrences="2">
       <code>$flattenedMetadata</code>
       <code>$flattenedMetadata</code>
@@ -523,185 +384,5 @@
       <code>$type</code>
       <code>$type</code>
     </UnusedClosureParam>
-  </file>
-  <file src="vendor/laravel/framework/src/Illuminate/Auth/CreatesUserProviders.php">
-    <ParseError occurrences="8">
-      <code>,</code>
-      <code>,</code>
-      <code>,</code>
-      <code>=&gt;</code>
-      <code>protected</code>
-      <code>protected</code>
-      <code>public</code>
-      <code>}</code>
-    </ParseError>
-  </file>
-  <file src="vendor/laravel/framework/src/Illuminate/Database/Connection.php">
-    <ParseError occurrences="54">
-      <code>$callback</code>
-      <code>,</code>
-      <code>,</code>
-      <code>,</code>
-      <code>=&gt;</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>return</code>
-      <code>}</code>
-    </ParseError>
-  </file>
-  <file src="vendor/laravel/framework/src/Illuminate/Database/Connectors/ConnectionFactory.php">
-    <ParseError occurrences="8">
-      <code>,</code>
-      <code>,</code>
-      <code>,</code>
-      <code>,</code>
-      <code>,</code>
-      <code>,</code>
-      <code>=&gt;</code>
-      <code>=&gt;</code>
-    </ParseError>
-  </file>
-  <file src="vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php">
-    <ParseError occurrences="52">
-      <code>;</code>
-      <code>=&gt;</code>
-      <code>protected</code>
-      <code>protected</code>
-      <code>protected</code>
-      <code>protected</code>
-      <code>protected</code>
-      <code>protected</code>
-      <code>protected</code>
-      <code>protected</code>
-      <code>protected</code>
-      <code>protected</code>
-      <code>protected</code>
-      <code>protected</code>
-      <code>protected</code>
-      <code>protected</code>
-      <code>protected</code>
-      <code>protected</code>
-      <code>protected</code>
-      <code>protected</code>
-      <code>protected</code>
-      <code>protected</code>
-      <code>protected</code>
-      <code>protected</code>
-      <code>protected</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>public</code>
-      <code>}</code>
-    </ParseError>
-  </file>
-  <file src="vendor/laravel/framework/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php">
-    <ParseError occurrences="1">
-      <code>,</code>
-    </ParseError>
-  </file>
-  <file src="vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php">
-    <ParseError occurrences="1">
-      <code>=&gt;</code>
-    </ParseError>
-  </file>
-  <file src="vendor/laravel/framework/src/Illuminate/Http/Request.php">
-    <ParseError occurrences="4">
-      <code>)</code>
-      <code>)</code>
-      <code>=&gt;</code>
-      <code>=&gt;</code>
-    </ParseError>
-  </file>
-  <file src="vendor/laravel/framework/src/Illuminate/Mail/Message.php">
-    <ParseError occurrences="2">
-      <code>,</code>
-      <code>=&gt;</code>
-    </ParseError>
-  </file>
-  <file src="vendor/laravel/framework/src/Illuminate/Routing/UrlGenerator.php">
-    <ParseError occurrences="2">
-      <code>)</code>
-      <code>=&gt;</code>
-    </ParseError>
-  </file>
-  <file src="vendor/laravel/framework/src/Illuminate/Support/Str.php">
-    <ParseError occurrences="8">
-      <code>,</code>
-      <code>,</code>
-      <code>,</code>
-      <code>,</code>
-      <code>=&gt;</code>
-      <code>=&gt;</code>
-      <code>=&gt;</code>
-      <code>=&gt;</code>
-    </ParseError>
   </file>
 </files>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -21,6 +21,11 @@
         <file name="tests/psalm-stubs.php"/>
     </stubs>
     <issueHandlers>
+        <PropertyNotSetInConstructor>
+            <errorLevel type="info">
+                <file name="src/Laravel/Console/Commands/CoreAgent.php" />
+            </errorLevel>
+        </PropertyNotSetInConstructor>
         <DeprecatedClass>
             <errorLevel type="info">
                 <!-- Handles usage of composer/package-versions-deprecated -->

--- a/src/Config.php
+++ b/src/Config.php
@@ -16,7 +16,9 @@ use Scoutapm\Config\Source\EnvSource;
 use Scoutapm\Config\Source\NullSource;
 use Scoutapm\Config\Source\UserSettingsSource;
 use Scoutapm\Config\TypeCoercion\CoerceBoolean;
+use Scoutapm\Config\TypeCoercion\CoerceInt;
 use Scoutapm\Config\TypeCoercion\CoerceJson;
+use Scoutapm\Config\TypeCoercion\CoerceString;
 use Scoutapm\Config\TypeCoercion\CoerceType;
 
 use function array_combine;
@@ -52,13 +54,27 @@ class Config
 
         $this->coercions = [
             ConfigKey::MONITORING_ENABLED => new CoerceBoolean(),
+            ConfigKey::LOG_PAYLOAD_CONTENT => new CoerceBoolean(),
+            ConfigKey::ERRORS_ENABLED => new CoerceBoolean(),
+            ConfigKey::CORE_AGENT_DOWNLOAD_ENABLED => new CoerceBoolean(),
+            ConfigKey::CORE_AGENT_LAUNCH_ENABLED => new CoerceBoolean(),
             ConfigKey::IGNORED_ENDPOINTS => new CoerceJson(),
             ConfigKey::DISABLED_INSTRUMENTS => new CoerceJson(),
-            ConfigKey::LOG_PAYLOAD_CONTENT => new CoerceBoolean(),
             ConfigKey::URI_FILTERED_PARAMETERS => new CoerceJson(),
-            ConfigKey::ERRORS_ENABLED => new CoerceBoolean(),
             ConfigKey::ERRORS_IGNORED_EXCEPTIONS => new CoerceJson(),
             ConfigKey::ERRORS_FILTERED_PARAMETERS => new CoerceJson(),
+            ConfigKey::CORE_AGENT_PERMISSIONS => new CoerceInt(),
+            ConfigKey::ERRORS_BATCH_SIZE => new CoerceInt(),
+            ConfigKey::API_VERSION => new CoerceString(),
+            ConfigKey::CORE_AGENT_DIRECTORY => new CoerceString(),
+            ConfigKey::CORE_AGENT_VERSION => new CoerceString(),
+            ConfigKey::CORE_AGENT_DOWNLOAD_URL => new CoerceString(),
+            ConfigKey::LOG_LEVEL => new CoerceString(),
+            ConfigKey::ERRORS_HOST => new CoerceString(),
+            ConfigKey::URI_REPORTING => new CoerceString(),
+            ConfigKey::CORE_AGENT_SOCKET_PATH => new CoerceString(),
+            ConfigKey::CORE_AGENT_FULL_NAME => new CoerceString(),
+            ConfigKey::CORE_AGENT_TRIPLE => new CoerceString(),
         ];
     }
 
@@ -78,7 +94,18 @@ class Config
      * Looks through all available sources for the first that can handle this
      * key, then returns the value from that source.
      *
-     * @return mixed
+     * @param K $key
+     *
+     * @return bool|mixed[]|int|string|null
+     * @psalm-return (
+     *   K is ConfigKey::MONITORING_ENABLED|ConfigKey::LOG_PAYLOAD_CONTENT|ConfigKey::ERRORS_ENABLED|ConfigKey::CORE_AGENT_DOWNLOAD_ENABLED|ConfigKey::CORE_AGENT_LAUNCH_ENABLED ? bool
+     *   : K is ConfigKey::IGNORED_ENDPOINTS|ConfigKey::DISABLED_INSTRUMENTS|ConfigKey::URI_FILTERED_PARAMETERS|ConfigKey::ERRORS_IGNORED_EXCEPTIONS|ConfigKey::ERRORS_FILTERED_PARAMETERS ? array|null
+     *   : K is ConfigKey::CORE_AGENT_PERMISSIONS|ConfigKey::ERRORS_BATCH_SIZE ? int
+     *   : K is ConfigKey::API_VERSION|ConfigKey::CORE_AGENT_DIRECTORY|ConfigKey::CORE_AGENT_VERSION|ConfigKey::CORE_AGENT_DOWNLOAD_URL|ConfigKey::LOG_LEVEL|ConfigKey::ERRORS_HOST|ConfigKey::URI_REPORTING|ConfigKey::CORE_AGENT_SOCKET_PATH|ConfigKey::CORE_AGENT_FULL_NAME|ConfigKey::CORE_AGENT_TRIPLE ? string
+     *   : string|null
+     * )
+     *
+     * @template K as string
      */
     public function get(string $key)
     {

--- a/src/Config/TypeCoercion/CoerceInt.php
+++ b/src/Config/TypeCoercion/CoerceInt.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scoutapm\Config\TypeCoercion;
+
+/** @internal */
+final class CoerceInt implements CoerceType
+{
+    /** {@inheritDoc} */
+    public function coerce($value): int
+    {
+        return (int) $value;
+    }
+}

--- a/src/Config/TypeCoercion/CoerceString.php
+++ b/src/Config/TypeCoercion/CoerceString.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scoutapm\Config\TypeCoercion;
+
+/** @internal */
+final class CoerceString implements CoerceType
+{
+    /** {@inheritDoc} */
+    public function coerce($value): string
+    {
+        return (string) $value;
+    }
+}

--- a/src/Laravel/Console/Commands/CoreAgent.php
+++ b/src/Laravel/Console/Commands/CoreAgent.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scoutapm\Laravel\Console\Commands;
+
+use Illuminate\Console\Command;
+use Scoutapm\CoreAgent\Downloader;
+use Scoutapm\CoreAgent\Launcher;
+use Scoutapm\CoreAgent\Verifier;
+
+use function sprintf;
+
+/** @internal */
+final class CoreAgent extends Command
+{
+    /** @var string */
+    protected $signature = 'scoutapm:core-agent {--download : Supply this flag if the Core Agent should be downloaded} {--launch : Supply this flag if the Core Agent should be launched}';
+    /** @var string|null */
+    protected $description = 'Manage the ScoutAPM core agent';
+
+    public function handle(Verifier $verifier, Downloader $downloader, Launcher $launcher): int
+    {
+        $shouldDownload = $this->option('download');
+        $shouldLaunch   = $this->option('launch');
+
+        if (! $shouldDownload && ! $shouldLaunch) {
+            $this->warn('You must specify --download and/or --launch flags');
+
+            return 1;
+        }
+
+        if ($shouldDownload) {
+            if (! $this->downloadIfNeeded($verifier, $downloader)) {
+                return 1;
+            }
+        }
+
+        if (! $shouldLaunch) {
+            return 0;
+        }
+
+        if (! $this->launchIfExists($verifier, $launcher)) {
+            return 1;
+        }
+
+        return 0;
+    }
+
+    private function downloadIfNeeded(Verifier $verifier, Downloader $downloader): bool
+    {
+        $this->info('Checking if core agent already exists...');
+        $coreAgentBinPath = $verifier->verify();
+
+        if ($coreAgentBinPath !== null) {
+            $this->warn(sprintf('Core agent already exists at: %s', $coreAgentBinPath));
+
+            return true;
+        }
+
+        $this->info('Core agent does not exist, downloading...');
+
+        $downloader->download();
+
+        $coreAgentBinPath = $verifier->verify();
+
+        if ($coreAgentBinPath === null) {
+            $this->error('Failed to download Core Agent - check the logs');
+
+            return false;
+        }
+
+        $this->info(sprintf('Download complete to: %s', $coreAgentBinPath));
+
+        return true;
+    }
+
+    private function launchIfExists(Verifier $verifier, Launcher $launcher): bool
+    {
+        $coreAgentBinPath = $verifier->verify();
+        if ($coreAgentBinPath === null) {
+            $this->error('Could not verify that Core Agent exists');
+
+            return false;
+        }
+
+        $launcher->launch($coreAgentBinPath);
+
+        $this->info(sprintf('Launch of %s completed.', $coreAgentBinPath));
+
+        return true;
+    }
+}

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Scoutapm\Config;
 use Scoutapm\Config\ConfigKey;
 
+use function json_encode;
 use function putenv;
 
 /** @covers \Scoutapm\Config*/
@@ -92,5 +93,86 @@ final class ConfigTest extends TestCase
         self::assertSame('<redacted>', $configArray['key']);
         self::assertArrayHasKey('monitor', $configArray);
         self::assertTrue($configArray['monitor']);
+    }
+
+    public function testDefinedCoercions(): void
+    {
+        $generateStringableClass =
+            static function (string $theString): object {
+                return new class ($theString) {
+                    /** @var string */
+                    private $theString;
+
+                    public function __construct(string $theString)
+                    {
+                        $this->theString = $theString;
+                    }
+
+                    public function __toString(): string
+                    {
+                        return $this->theString;
+                    }
+                };
+            };
+
+        self::assertSame(
+            [
+                'monitor' => true,
+                'name' => null,
+                'key' => '<redacted>',
+                'log_level' => 'log_level_value',
+                'log_payload_content' => false,
+                'api_version' => '1.1',
+                'ignore' => ['a','b'],
+                'application_root' => null,
+                'scm_subdirectory' => null,
+                'revision_sha' => null,
+                'hostname' => null,
+                'disabled_instruments' => ['a','b'],
+                'core_agent_log_level' => null,
+                'core_agent_log_file' => null,
+                'core_agent_config_file' => null,
+                'core_agent_socket_path' => 'core_agent_socket_path_value',
+                'core_agent_dir' => 'core_agent_dir_value',
+                'core_agent_full_name' => 'core_agent_full_name_value',
+                'core_agent_download_url' => 'core_agent_download_url_value',
+                'core_agent_launch' => true,
+                'core_agent_download' => true,
+                'core_agent_version' => 'core_agent_version_value',
+                'core_agent_triple' => 'core_agent_triple_value',
+                'core_agent_permissions' => 0777,
+                'uri_reporting' => 'uri_reporting_value',
+                'uri_filtered_params' => ['a','b'],
+                'errors_enabled' => false,
+                'errors_ignored_exceptions' => ['a','b'],
+                'errors_host' => 'errors_host_value',
+                'errors_batch_size' => 3,
+                'errors_filtered_params' => ['a','b'],
+            ],
+            Config::fromArray([
+                ConfigKey::MONITORING_ENABLED => 'true',
+                ConfigKey::LOG_PAYLOAD_CONTENT => 'false',
+                ConfigKey::ERRORS_ENABLED => '0',
+                ConfigKey::CORE_AGENT_DOWNLOAD_ENABLED => '1',
+                ConfigKey::CORE_AGENT_LAUNCH_ENABLED => '1',
+                ConfigKey::IGNORED_ENDPOINTS => json_encode(['a', 'b']),
+                ConfigKey::DISABLED_INSTRUMENTS => json_encode(['a', 'b']),
+                ConfigKey::URI_FILTERED_PARAMETERS => json_encode(['a', 'b']),
+                ConfigKey::ERRORS_IGNORED_EXCEPTIONS => json_encode(['a', 'b']),
+                ConfigKey::ERRORS_FILTERED_PARAMETERS => json_encode(['a', 'b']),
+                ConfigKey::CORE_AGENT_PERMISSIONS => '511',
+                ConfigKey::ERRORS_BATCH_SIZE => 3,
+                ConfigKey::API_VERSION => 1.1,
+                ConfigKey::CORE_AGENT_DIRECTORY => $generateStringableClass('core_agent_dir_value'),
+                ConfigKey::CORE_AGENT_VERSION => $generateStringableClass('core_agent_version_value'),
+                ConfigKey::CORE_AGENT_DOWNLOAD_URL => $generateStringableClass('core_agent_download_url_value'),
+                ConfigKey::LOG_LEVEL => $generateStringableClass('log_level_value'),
+                ConfigKey::ERRORS_HOST => $generateStringableClass('errors_host_value'),
+                ConfigKey::URI_REPORTING => $generateStringableClass('uri_reporting_value'),
+                ConfigKey::CORE_AGENT_SOCKET_PATH => $generateStringableClass('core_agent_socket_path_value'),
+                ConfigKey::CORE_AGENT_FULL_NAME => $generateStringableClass('core_agent_full_name_value'),
+                ConfigKey::CORE_AGENT_TRIPLE => $generateStringableClass('core_agent_triple_value'),
+            ])->asArrayWithSecretsRemoved()
+        );
     }
 }

--- a/tests/Unit/Laravel/Providers/ScoutApmServiceProviderTestBase.php
+++ b/tests/Unit/Laravel/Providers/ScoutApmServiceProviderTestBase.php
@@ -51,8 +51,7 @@ use function uniqid;
 
 abstract class ScoutApmServiceProviderTestBase extends TestCase
 {
-    private const CONFIG_SERVICE_KEY = ScoutApmAgent::class . '_config';
-    private const CACHE_SERVICE_KEY  = ScoutApmAgent::class . '_cache';
+    private const CACHE_SERVICE_KEY = ScoutApmAgent::class . '_cache';
 
     protected const VIEW_ENGINES_TO_WRAP = ['file', 'php', 'blade'];
 
@@ -457,7 +456,7 @@ abstract class ScoutApmServiceProviderTestBase extends TestCase
         $this->application->singleton(ScoutApmAgent::class, function () use ($connectorMock) {
             /** @psalm-suppress InvalidArgument */
             return Agent::fromConfig(
-                $this->application->make(self::CONFIG_SERVICE_KEY),
+                $this->application->make(Config::class),
                 $this->application->make(FilteredLogLevelDecorator::class),
                 $this->application->make(self::CACHE_SERVICE_KEY),
                 $connectorMock


### PR DESCRIPTION
Fixes scoutapp/scout-apm-laravel#14

### Docs

Change adds a new Artisan command for Laravel installations.

```bash
php artisan scoutapm:core-agent [--download] [--launch]
```

You must specify at least one of `--download` and `--launch` flags.

It is recommended that you specify `SCOUT_LOG_LEVEL=warning` or higher in `.env` before running this as the output can be quite noisy, or alternatively, you can override on a per-command basis:

```bash
SCOUT_LOG_LEVEL=warning php artisan scoutapm:core-agent --download --launch
```