### PR TITLE
Add configuration to ignore jobs

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -536,11 +536,14 @@ final class Agent implements ScoutApmAgent
 
             $this->errorHandling->sendCollectedErrors();
 
-            $shouldLogContent = $this->config->get(ConfigKey::LOG_PAYLOAD_CONTENT);
+            $shouldLogContent    = $this->config->get(ConfigKey::LOG_PAYLOAD_CONTENT);
+            $collectedSpans      = $this->request->collectedSpans();
+            $controllerOrJobName = $this->request->controllerOrJobName() ?: '(unknown)';
 
             $this->logger->debug(sprintf(
-                'Sending metrics from %d collected spans.%s',
-                $this->request->collectedSpans(),
+                'Sending metrics from request %s with %d collected spans.%s',
+                $controllerOrJobName,
+                $collectedSpans,
                 $shouldLogContent ? sprintf(' Payload: %s', json_encode($this->request)) : ''
             ));
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -59,6 +59,7 @@ class Config
             ConfigKey::CORE_AGENT_DOWNLOAD_ENABLED => new CoerceBoolean(),
             ConfigKey::CORE_AGENT_LAUNCH_ENABLED => new CoerceBoolean(),
             ConfigKey::IGNORED_ENDPOINTS => new CoerceJson(),
+            ConfigKey::IGNORED_JOBS => new CoerceJson(),
             ConfigKey::DISABLED_INSTRUMENTS => new CoerceJson(),
             ConfigKey::URI_FILTERED_PARAMETERS => new CoerceJson(),
             ConfigKey::ERRORS_IGNORED_EXCEPTIONS => new CoerceJson(),
@@ -99,7 +100,7 @@ class Config
      * @return bool|mixed[]|int|string|null
      * @psalm-return (
      *   K is ConfigKey::MONITORING_ENABLED|ConfigKey::LOG_PAYLOAD_CONTENT|ConfigKey::ERRORS_ENABLED|ConfigKey::CORE_AGENT_DOWNLOAD_ENABLED|ConfigKey::CORE_AGENT_LAUNCH_ENABLED ? bool
-     *   : K is ConfigKey::IGNORED_ENDPOINTS|ConfigKey::DISABLED_INSTRUMENTS|ConfigKey::URI_FILTERED_PARAMETERS|ConfigKey::ERRORS_IGNORED_EXCEPTIONS|ConfigKey::ERRORS_FILTERED_PARAMETERS ? array|null
+     *   : K is ConfigKey::IGNORED_ENDPOINTS|ConfigKey::IGNORED_JOBS|ConfigKey::DISABLED_INSTRUMENTS|ConfigKey::URI_FILTERED_PARAMETERS|ConfigKey::ERRORS_IGNORED_EXCEPTIONS|ConfigKey::ERRORS_FILTERED_PARAMETERS ? array|null
      *   : K is ConfigKey::CORE_AGENT_PERMISSIONS|ConfigKey::ERRORS_BATCH_SIZE ? int
      *   : K is ConfigKey::API_VERSION|ConfigKey::CORE_AGENT_DIRECTORY|ConfigKey::CORE_AGENT_VERSION|ConfigKey::CORE_AGENT_DOWNLOAD_URL|ConfigKey::LOG_LEVEL|ConfigKey::ERRORS_HOST|ConfigKey::URI_REPORTING|ConfigKey::CORE_AGENT_SOCKET_PATH|ConfigKey::CORE_AGENT_FULL_NAME|ConfigKey::CORE_AGENT_TRIPLE ? string
      *   : string|null

--- a/src/Config/ConfigKey.php
+++ b/src/Config/ConfigKey.php
@@ -18,6 +18,7 @@ abstract class ConfigKey
     public const LOG_PAYLOAD_CONTENT         = 'log_payload_content';
     public const API_VERSION                 = 'api_version';
     public const IGNORED_ENDPOINTS           = 'ignore';
+    public const IGNORED_JOBS                = 'ignore_jobs';
     public const APPLICATION_ROOT            = 'application_root';
     public const SCM_SUBDIRECTORY            = 'scm_subdirectory';
     public const REVISION_SHA                = 'revision_sha';

--- a/src/Config/Source/DefaultSource.php
+++ b/src/Config/Source/DefaultSource.php
@@ -56,6 +56,7 @@ final class DefaultSource implements ConfigSource
             ConfigKey::CORE_AGENT_PERMISSIONS => 0777,
             ConfigKey::MONITORING_ENABLED => false,
             ConfigKey::IGNORED_ENDPOINTS => [],
+            ConfigKey::IGNORED_JOBS => ['horizon'],
             ConfigKey::LOG_LEVEL => Config::DEFAULT_LOG_LEVEL,
             ConfigKey::LOG_PAYLOAD_CONTENT => false,
             ConfigKey::ERRORS_ENABLED => false,

--- a/src/Laravel/Console/ConsoleListener.php
+++ b/src/Laravel/Console/ConsoleListener.php
@@ -35,7 +35,13 @@ final class ConsoleListener
             return;
         }
 
+        $commandName = $commandStartingEvent->command;
+
         $this->agent->startNewRequest();
+
+        if ($this->agent->ignored($commandName)) {
+            $this->agent->ignore($commandName);
+        }
 
         $this->agent->addContext(Tag::TAG_ARGUMENTS, implode(' ', $this->argv));
 
@@ -43,7 +49,7 @@ final class ConsoleListener
         $this->agent->startSpan(sprintf(
             '%s/artisan/%s',
             SpanReference::INSTRUMENT_JOB,
-            $commandStartingEvent->command
+            $commandName
         ));
     }
 

--- a/src/Laravel/Middleware/IgnoredEndpoints.php
+++ b/src/Laravel/Middleware/IgnoredEndpoints.php
@@ -24,7 +24,7 @@ final class IgnoredEndpoints
         // Check if the request path we're handling is configured to be
         // ignored, and if so, mark it as such.
         if ($this->agent->ignored('/' . $request->path())) {
-            $this->agent->ignore();
+            $this->agent->ignore('/' . $request->path());
         }
 
         return $next($request);

--- a/src/Laravel/Queue/JobQueueListener.php
+++ b/src/Laravel/Queue/JobQueueListener.php
@@ -30,11 +30,17 @@ final class JobQueueListener
     /** @throws Exception */
     public function startSpanForJob(JobProcessing $jobProcessingEvent): void
     {
+        $jobName = class_basename($jobProcessingEvent->job->resolveName());
+
+        if ($this->agent->ignored($jobName)) {
+            $this->agent->ignore($jobName);
+        }
+
         /** @noinspection UnusedFunctionResultInspection */
         $this->agent->startSpan(sprintf(
             '%s/%s',
             SpanReference::INSTRUMENT_JOB,
-            class_basename($jobProcessingEvent->job->resolveName())
+            $jobName
         ));
     }
 

--- a/src/ScoutApmAgent.php
+++ b/src/ScoutApmAgent.php
@@ -91,7 +91,7 @@ interface ScoutApmAgent
      * Mark the running request as ignored. Triggers optimizations in various
      * tracing and tagging methods to turn them into NOOPs
      */
-    public function ignore(): void;
+    public function ignore(?string $ignoreReason = null): void;
 
     /**
      * Should the instrumentation be enabled for a particular functionality. This checks the `disabled_instruments`

--- a/tests/Unit/AgentTest.php
+++ b/tests/Unit/AgentTest.php
@@ -926,7 +926,7 @@ final class AgentTest extends TestCase
         );
         $agent->send();
 
-        self::assertTrue($this->logger->hasDebugThatContains('Sending metrics from 2 collected spans. Payload: {'));
+        self::assertTrue($this->logger->hasDebugThatContains('Sending metrics from request (unknown) with 2 collected spans. Payload: {'));
         self::assertTrue($this->logger->hasDebugThatContains('Sent whole payload successfully to core agent. Response: {"Request":"Success"}'));
     }
 


### PR DESCRIPTION
* Adds new config key `ignore_jobs` (environment variable `SCOUT_IGNORE_JOBS`)
  * Value is a `list<string>`
  * Default value is `["horizon"]` which will ignore all Laravel Horizon jobs
  * Example: `SCOUT_IGNORE_JOBS="[\"horizon\",\"foo\"]"` would ignore all jobs starting "horizon*" and "foo*" (e.g. `horizon:work`).
* Tweaked the debug log output when sending metrics from `Sending metrics from %d collected spans.` to `Sending metrics from request %s with %d collected spans.` (to include the controller or job name, if found - note bug #296 needs to be fixed, at the moment a lot of `(unknown)` will be seen currently)
* `ignore()` function now optionally takes a parameter as the "reason" for ignoring the request. This is output in debug log now, if set, e.g. `Not sending payload, request has been ignored (horizon:work)`