### PR TITLE
Fix an unconstrained CI require for spatie/laravel-ignition

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -405,7 +405,8 @@ jobs:
         run: "composer require laravel/framework:${{ matrix.laravel-version}} --no-update --no-interaction --prefer-dist --prefer-stable"
       - name: "Install spatie/laravel-ignition (if available)"
         if: ${{ (matrix.php-version == '8.0' || matrix.php-version == '8.1') && (matrix.laravel-version == '8.*' || matrix.laravel-version == '9.*') }}
-        run: "composer require --dev spatie/laravel-ignition --no-update --no-interaction"
+        # Note: for Laravel 10, we will need to use `spatie/laravel-ignition:^2.0`
+        run: "composer require --dev spatie/laravel-ignition:^1.6 --no-update --no-interaction"
       - name: "Unrestrict nesbot/carbon for older PHP versions"
         if: ${{ (matrix.php-version == '7.2' || matrix.php-version == '7.3' || matrix.php-version == '7.4' || matrix.php-version == '8.0' || matrix.php-version == '8.1') }}
         run: "composer remove --dev --no-update --no-interaction nesbot/carbon"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -115,7 +115,7 @@ jobs:
       SCOUT_APM_KEY: ${{ secrets.SCOUT_APM_KEY }}
     steps:
       - uses: actions/checkout@v3
-      - uses: Vampire/setup-wsl@v1
+      - uses: Vampire/setup-wsl@v2
         if: ${{ matrix.os == 'windows-latest' }}
       - name: "Install PHP"
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -117,6 +117,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: Vampire/setup-wsl@v2
         if: ${{ matrix.os == 'windows-latest' }}
+        with:
+          update: 'true'
       - name: "Install PHP"
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -119,6 +119,11 @@ jobs:
         if: ${{ matrix.os == 'windows-latest' }}
         with:
           update: 'true'
+      - name: "Update CA certificates"
+        shell: wsl-bash {0}
+        run: |
+          apt-get update && apt-get install -y ca-certificates
+          update-ca-certificates
       - name: "Install PHP"
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -117,13 +117,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: Vampire/setup-wsl@v2
         if: ${{ matrix.os == 'windows-latest' }}
-        with:
-          update: 'true'
-      - name: "Update CA certificates"
-        shell: wsl-bash {0}
-        run: |
-          apt-get update && apt-get install -y ca-certificates
-          update-ca-certificates
       - name: "Install PHP"
         uses: shivammathur/setup-php@v2
         with:


### PR DESCRIPTION
Fix an unconstrained CI require for `spatie/laravel-ignition` that was trying to install `^2.0` series. The `^2.0` series is only for Laravel 10, which we will add support for separately.

Scheduled run failed: https://github.com/scoutapp/scout-apm-php/actions/runs/4062948737