### PR TITLE
Added reference to decorated lastCompiled property if it exists

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -526,6 +526,9 @@ jobs:
           wget --content-on-error -O error.html http://localhost:8000/e || true
           cat error.html
           ps -ax
+      - name: "Output logs on failure"
+        if: failure()
+        run: cat test-app/storage/logs/laravel.log
       - name: "Check logs for successful payload send"
         run: |
           cd test-app
@@ -791,6 +794,9 @@ jobs:
           wget http://localhost:8000
           cat index.html
           ps -ax
+      - name: "Output logs on failure"
+        if: failure()
+        run: cat test-app/storage/logs/lumen.log
       - name: "Check logs for successful payload send"
         run: |
           cd test-app

--- a/src/Laravel/View/Engine/ScoutViewEngineDecorator.php
+++ b/src/Laravel/View/Engine/ScoutViewEngineDecorator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Scoutapm\Laravel\View\Engine;
 
+use Closure;
 use Illuminate\Contracts\View\Engine;
 use Illuminate\View\Compilers\CompilerInterface;
 use Illuminate\View\Factory;
@@ -57,9 +58,15 @@ final class ScoutViewEngineDecorator implements Engine
 
         /**
          * @psalm-suppress MixedAssignment
-         * @psalm-suppress NoInterfaceProperties
+         * @psalm-suppress PossiblyInvalidFunctionCall
          */
-        $this->lastCompiled = &$engine->lastCompiled;
+        $this->lastCompiled = & Closure::bind(
+            function & () {
+                return $this->lastCompiled;
+            },
+            $engine,
+            $engine
+        )->__invoke();
     }
 
     /**

--- a/tests/Unit/Laravel/View/Engine/EngineImplementationWithGetCompilerMethod.php
+++ b/tests/Unit/Laravel/View/Engine/EngineImplementationWithGetCompilerMethod.php
@@ -9,10 +9,19 @@ use Illuminate\View\Compilers\CompilerInterface;
 
 class EngineImplementationWithGetCompilerMethod implements Engine
 {
+    /** @var list<non-empty-string> */
+    protected $lastCompiled = [];
+
     /** @inheritDoc */
     public function get($path, array $data = [])
     {
         return '';
+    }
+
+    /** @param list<non-empty-string> $newValue */
+    public function setLastCompiled(array $newValue): void
+    {
+        $this->lastCompiled = $newValue;
     }
 
     public function getCompiler(): CompilerInterface

--- a/tests/Unit/Laravel/View/Engine/ScoutViewEngineDecoratorTest.php
+++ b/tests/Unit/Laravel/View/Engine/ScoutViewEngineDecoratorTest.php
@@ -173,24 +173,19 @@ final class ScoutViewEngineDecoratorTest extends TestCase
         }
     }
 
+    /**
+     * The `spatie/laravel-ignition` package depends on the engine having a property called `lastCompiled`, which
+     * only exists in the `\Illuminate\View\Engines\CompilerEngine` Blade Compiler. The implementation does sort of
+     * account for decoration, but it expects the property to be called `engine`. Therefore, in this test, we
+     * invoke the problematic consumer to ensure our decorated view engine conforms to this assumption.
+     *
+     * @link https://github.com/spatie/laravel-ignition/blob/d53075177ee0c710fbf588b8569f50435e1da054/src/Views/ViewExceptionMapper.php#L124-L130
+     */
     public function testSpatieLaravelIgnitionCompatibility(): void
     {
         if (! class_exists(ViewExceptionMapper::class)) {
             self::markTestSkipped('Test depends on `spatie/laravel-ignition`, but it is not installed');
         }
-
-        /**
-         * The `spatie/laravel-ignition` package depends on the engine having a property called `lastCompiled`, which
-         * only exists in the `\Illuminate\View\Engines\CompilerEngine` Blade Compiler. The implementation does sort of
-         * account for decoration, but it expects the property to be called `engine`. Therefore, in this test, we
-         * invoke the problematic consumer to ensure our decorated view engine conforms to this assumption.
-         *
-         * @link https://github.com/spatie/laravel-ignition/blob/d53075177ee0c710fbf588b8569f50435e1da054/src/Views/ViewExceptionMapper.php#L124-L130
-         *
-         * @noinspection PhpPossiblePolymorphicInvocationInspection
-         * @psalm-suppress NoInterfaceProperties
-         */
-        $this->realEngine->lastCompiled = [];
 
         $viewEngineResolver = new EngineResolver();
         $viewEngineResolver->register('blade', function () {

--- a/tests/Unit/Laravel/View/Engine/ScoutViewEngineDecoratorTest.php
+++ b/tests/Unit/Laravel/View/Engine/ScoutViewEngineDecoratorTest.php
@@ -211,24 +211,17 @@ final class ScoutViewEngineDecoratorTest extends TestCase
     /** @throws ReflectionException */
     public function testDecoratorLastCompiledPropertyReferencesCompilerEngineLastCompiledPropertyWhenUsingReflection(): void
     {
-        /**
-         * @noinspection PhpPossiblePolymorphicInvocationInspection
-         * @psalm-suppress NoInterfaceProperties
-         */
-        $this->realEngine->lastCompiled = ['a', 'b'];
+        $realEngine = new EngineImplementationWithGetCompilerMethod();
+        $realEngine->setLastCompiled(['a', 'b']);
 
-        $this->viewEngineDecorator = new ScoutViewEngineDecorator($this->realEngine, $this->agent, $this->viewFactory);
+        $this->viewEngineDecorator = new ScoutViewEngineDecorator($realEngine, $this->agent, $this->viewFactory);
 
         $prop = new ReflectionProperty($this->viewEngineDecorator, 'lastCompiled');
         $prop->setAccessible(true);
         self::assertSame(['a', 'b'], $prop->getValue($this->viewEngineDecorator));
 
-        /**
-         * @noinspection PhpPossiblePolymorphicInvocationInspection
-         * @psalm-suppress NoInterfaceProperties
-         */
-        $this->realEngine->lastCompiled = ['a', 'b', 'c'];
-
+        // Make sure the value can be changed at runtime, and the decorator's value is also changed
+        $realEngine->setLastCompiled(['a', 'b', 'c']);
         self::assertSame(['a', 'b', 'c'], $prop->getValue($this->viewEngineDecorator));
     }
 }


### PR DESCRIPTION
```
ReflectionException: Property Scoutapm\Laravel\View\Engine\ScoutViewEngineDecorator::$lastCompiled does not exist
```

Something (not sure what, at present) is trying to reflect on the view engine (to access the `protected` property `$lastCompiled`), which we decorate with `ScoutViewEngineDecorator`; but since `ScoutViewEngineDecorator` does not have that property, it fails. In order to play nicely, this PR proposes adding a reference to the decorated property (if it exists, since properties are not part of interfaces!).